### PR TITLE
优化空教室查询页面的楼栋筛选与搜索体验

### DIFF
--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomQueryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomQueryScreen.kt
@@ -1,14 +1,50 @@
 package cn.edu.ubaa.ui.screens.classroom
 
-import androidx.compose.foundation.*
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,14 +57,24 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
-/**
- * 教室查询功能屏幕。 结合了美观的视觉风格（圆角、配色）与紧凑的布局（一页展示14节课）。
- *
- * @param viewModel 控制查询逻辑的状态机。
- * @param onBackClick 点击返回按钮的回调。
- */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+private const val LABEL_CONFIRM = "\u786e\u5b9a"
+private const val LABEL_CANCEL = "\u53d6\u6d88"
+private const val LABEL_CAMPUS_XYL = "\u5b66\u9662\u8def"
+private const val LABEL_CAMPUS_SH = "\u6c99\u6cb3"
+private const val LABEL_CAMPUS_HZ = "\u676d\u5dde"
+private const val LABEL_PICK_DATE = "\u9009\u62e9\u65e5\u671f"
+private const val LABEL_SEARCH_PLACEHOLDER = "\u641c\u7d22\u6559\u5ba4"
+private const val LABEL_FREE = " \u7a7a\u95f2"
+private const val LABEL_LOADING = "\u6b63\u5728\u67e5\u8be2..."
+private const val LABEL_EMPTY = "\u672a\u627e\u5230\u5339\u914d\u7684\u6559\u5ba4"
+private const val LABEL_RETRY = "\u91cd\u8bd5"
+private const val LABEL_SELECT_BUILDING = "\u9009\u62e9\u697c\u680b"
+private const val LABEL_TABLE_CLASSROOM = "\u6559\u5ba4"
+private const val LABEL_ERROR_PREFIX = "\u67e5\u8be2\u5931\u8d25: "
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("UNUSED_PARAMETER")
 fun ClassroomQueryScreen(
   viewModel: ClassroomViewModel,
   onBackClick: () -> Unit,
@@ -38,10 +84,14 @@ fun ClassroomQueryScreen(
   val xqid by viewModel.xqid.collectAsState()
   val date by viewModel.date.collectAsState()
   val searchQuery by viewModel.searchQuery.collectAsState()
+  val selectedBuilding by viewModel.selectedBuilding.collectAsState()
+  val availableBuildings by viewModel.availableBuildings.collectAsState()
   val filteredData by viewModel.filteredData.collectAsState()
   var showDatePicker by remember { mutableStateOf(false) }
 
-  LaunchedEffect(Unit) { if (uiState is ClassroomUiState.Idle) viewModel.query() }
+  LaunchedEffect(Unit) {
+    if (uiState is ClassroomUiState.Idle) viewModel.query()
+  }
 
   if (showDatePicker) {
     val datePickerState = rememberDatePickerState()
@@ -58,10 +108,12 @@ fun ClassroomQueryScreen(
             showDatePicker = false
           }
         ) {
-          Text("确定")
+          Text(LABEL_CONFIRM)
         }
       },
-      dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text("取消") } },
+      dismissButton = {
+        TextButton(onClick = { showDatePicker = false }) { Text(LABEL_CANCEL) }
+      },
     ) {
       DatePicker(state = datePickerState)
     }
@@ -69,105 +121,181 @@ fun ClassroomQueryScreen(
 
   Column(modifier = modifier.fillMaxSize()) {
     Surface(tonalElevation = 2.dp, shadowElevation = 1.dp) {
-      Row(Modifier.fillMaxWidth().padding(8.dp), Arrangement.SpaceEvenly) {
-        CampusButton("学院路", 1, xqid == 1) { viewModel.setXqid(1) }
-        CampusButton("沙河", 2, xqid == 2) { viewModel.setXqid(2) }
-        CampusButton("杭州", 3, xqid == 3) { viewModel.setXqid(3) }
+      Row(
+        modifier = Modifier.fillMaxWidth().padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+      ) {
+        CampusButton(LABEL_CAMPUS_XYL, xqid == 1) { viewModel.setXqid(1) }
+        CampusButton(LABEL_CAMPUS_SH, xqid == 2) { viewModel.setXqid(2) }
+        CampusButton(LABEL_CAMPUS_HZ, xqid == 3) { viewModel.setXqid(3) }
       }
     }
 
     Row(
-      Modifier.fillMaxWidth().padding(16.dp, 8.dp),
-      Arrangement.spacedBy(8.dp),
-      Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      verticalAlignment = Alignment.CenterVertically,
     ) {
       OutlinedCard(
         onClick = { showDatePicker = true },
-        Modifier.weight(1f),
+        modifier = Modifier.weight(1f),
         shape = RoundedCornerShape(12.dp),
       ) {
         Row(
-          modifier = Modifier.padding(12.dp),
-          verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier.fillMaxWidth().padding(12.dp),
           horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically,
         ) {
           Text(text = date, style = MaterialTheme.typography.bodyMedium)
           Icon(
-            Icons.Default.DateRange,
-            null,
-            Modifier.size(20.dp),
-            MaterialTheme.colorScheme.primary,
+            imageVector = Icons.Default.DateRange,
+            contentDescription = LABEL_PICK_DATE,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.primary,
           )
         }
       }
-      OutlinedTextField(
-        value = searchQuery,
-        onValueChange = { viewModel.setSearchQuery(it) },
-        placeholder = { Text("搜索教室/楼栋") },
-        modifier = Modifier.weight(1.5f),
-        shape = RoundedCornerShape(12.dp),
-        singleLine = true,
-        leadingIcon = { Icon(Icons.Default.Search, null) },
+
+      BuildingDropdown(
+        buildings = availableBuildings,
+        selectedBuilding = selectedBuilding,
+        onSelect = viewModel::setSelectedBuilding,
+        modifier = Modifier.weight(1f),
       )
     }
 
-    // 简单的图例
+    OutlinedTextField(
+      value = searchQuery,
+      onValueChange = { viewModel.setSearchQuery(it) },
+      placeholder = { Text(LABEL_SEARCH_PLACEHOLDER) },
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+      shape = RoundedCornerShape(12.dp),
+      singleLine = true,
+      leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+    )
+
     Row(
-      Modifier.fillMaxWidth().padding(bottom = 8.dp),
+      modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 8.dp),
       horizontalArrangement = Arrangement.Center,
       verticalAlignment = Alignment.CenterVertically,
     ) {
       Box(
-        Modifier.size(12.dp)
-          .background(Color(0xFF98FB98), RoundedCornerShape(2.dp))
-          .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+        modifier =
+          Modifier.size(12.dp)
+            .background(Color(0xFF98FB98), RoundedCornerShape(2.dp))
+            .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
       )
-      Text(" 空闲", Modifier.padding(start = 4.dp), style = MaterialTheme.typography.labelSmall)
+      Text(
+        text = LABEL_FREE,
+        modifier = Modifier.padding(start = 4.dp),
+        style = MaterialTheme.typography.labelSmall,
+      )
     }
 
     when (val state = uiState) {
       is ClassroomUiState.Loading ->
-        Box(Modifier.fillMaxSize(), Alignment.Center) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
           Column(horizontalAlignment = Alignment.CenterHorizontally) {
             CircularProgressIndicator()
             Spacer(Modifier.height(8.dp))
-            Text("正在查询...")
+            Text(LABEL_LOADING)
           }
         }
       is ClassroomUiState.Success ->
-        if (filteredData.isEmpty())
-          Box(Modifier.fillMaxSize(), Alignment.Center) { Text("未找到匹配教室") }
-        else ClassroomTable(filteredData)
+        if (filteredData.isEmpty()) {
+          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(LABEL_EMPTY)
+          }
+        } else {
+          ClassroomTable(filteredData)
+        }
       is ClassroomUiState.Error ->
-        Box(Modifier.fillMaxSize().padding(16.dp), Alignment.Center) {
+        Box(
+          modifier = Modifier.fillMaxSize().padding(16.dp),
+          contentAlignment = Alignment.Center,
+        ) {
           Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(text = "查询失败: ${state.message}", color = MaterialTheme.colorScheme.error)
+            Text(
+              text = LABEL_ERROR_PREFIX + state.message,
+              color = MaterialTheme.colorScheme.error,
+            )
             Spacer(Modifier.height(16.dp))
-            Button(onClick = { viewModel.query() }) { Text("重试") }
+            Button(onClick = { viewModel.query() }) { Text(LABEL_RETRY) }
           }
         }
-      else -> {}
+      ClassroomUiState.Idle -> Unit
     }
   }
 }
 
 @Composable
-fun CampusButton(name: String, id: Int, selected: Boolean, onClick: () -> Unit) {
+private fun CampusButton(name: String, selected: Boolean, onClick: () -> Unit) {
   FilterChip(selected = selected, onClick = onClick, label = { Text(name) })
 }
 
-/** 教室排布表。 使用 LazyColumn 实现，包含表头和楼栋分组。 */
 @Composable
+private fun BuildingDropdown(
+  buildings: List<String>,
+  selectedBuilding: String,
+  onSelect: (String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var expanded by remember { mutableStateOf(false) }
+
+  Box(modifier = modifier) {
+    OutlinedCard(
+      onClick = { expanded = true },
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(12.dp),
+    ) {
+      Row(
+        modifier = Modifier.fillMaxWidth().padding(12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+          text = selectedBuilding,
+          style = MaterialTheme.typography.bodyMedium,
+          maxLines = 1,
+        )
+        Icon(
+          imageVector = Icons.Default.ArrowDropDown,
+          contentDescription = LABEL_SELECT_BUILDING,
+          tint = MaterialTheme.colorScheme.primary,
+        )
+      }
+    }
+
+    DropdownMenu(
+      expanded = expanded,
+      onDismissRequest = { expanded = false },
+      modifier = Modifier.fillMaxWidth(0.95f),
+    ) {
+      buildings.forEach { building ->
+        DropdownMenuItem(
+          text = { Text(building) },
+          onClick = {
+            expanded = false
+            onSelect(building)
+          },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
 fun ClassroomTable(list: Map<String, List<ClassroomInfo>>) {
-  LazyColumn(Modifier.fillMaxSize()) {
-    // 固定表头
+  LazyColumn(modifier = Modifier.fillMaxSize()) {
     stickyHeader {
       Row(
-        Modifier.fillMaxWidth()
-          .background(MaterialTheme.colorScheme.surface)
-          .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+        modifier =
+          Modifier.fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
       ) {
-        TableCell("教室", 2.2f, true)
+        TableCell(LABEL_TABLE_CLASSROOM, 2.2f, true)
         for (i in 1..14) {
           TableCell(i.toString(), 1f, true)
         }
@@ -178,21 +306,24 @@ fun ClassroomTable(list: Map<String, List<ClassroomInfo>>) {
       item { BuildingHeader(building) }
       items(classrooms) { ClassroomRow(it) }
     }
+
     item { Spacer(Modifier.height(16.dp)) }
   }
 }
 
-/** 楼栋分组标题 (恢复原有的圆角 Surface 风格)。 */
 @Composable
-fun BuildingHeader(name: String) {
-  Box(Modifier.fillMaxWidth().padding(vertical = 12.dp), Alignment.Center) {
+private fun BuildingHeader(name: String) {
+  Box(
+    modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+    contentAlignment = Alignment.Center,
+  ) {
     Surface(
       color = MaterialTheme.colorScheme.secondaryContainer,
       shape = RoundedCornerShape(4.dp),
     ) {
       Text(
         text = name,
-        Modifier.padding(24.dp, 4.dp),
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp),
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.Bold,
       )
@@ -200,23 +331,25 @@ fun BuildingHeader(name: String) {
   }
 }
 
-/** 教室详情行。 使用 Weight 布局实现一页宽度的 1-14 节课展示，无需水平滚动。 */
 @Composable
-fun ClassroomRow(classroom: ClassroomInfo) {
+private fun ClassroomRow(classroom: ClassroomInfo) {
   val freePeriods =
     remember(classroom.kxsds) {
       classroom.kxsds.split(",").mapNotNull { it.trim().toIntOrNull() }.toSet()
     }
 
   Row(
-    Modifier.fillMaxWidth().height(44.dp).border(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+    modifier =
+      Modifier.fillMaxWidth()
+        .height(44.dp)
+        .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
   ) {
-    // 教室名单元格
     Box(
-      Modifier.weight(2.2f)
-        .fillMaxHeight()
-        .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-      Alignment.Center,
+      modifier =
+        Modifier.weight(2.2f)
+          .fillMaxHeight()
+          .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
+      contentAlignment = Alignment.Center,
     ) {
       Text(
         text = classroom.name,
@@ -229,27 +362,27 @@ fun ClassroomRow(classroom: ClassroomInfo) {
       )
     }
 
-    // 1-14 节课状态单元格
     for (i in 1..14) {
       val isFree = i in freePeriods
       Box(
-        Modifier.weight(1f)
-          .fillMaxHeight()
-          .background(if (isFree) Color(0xFF98FB98) else Color.Transparent)
-          .border(0.3.dp, MaterialTheme.colorScheme.outlineVariant.copy(0.3f))
+        modifier =
+          Modifier.weight(1f)
+            .fillMaxHeight()
+            .background(if (isFree) Color(0xFF98FB98) else Color.Transparent)
+            .border(0.3.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
       )
     }
   }
 }
 
-/** 通用单元格容器 (表头用)。 */
 @Composable
-fun RowScope.TableCell(text: String, weight: Float, isHeader: Boolean) {
+private fun RowScope.TableCell(text: String, weight: Float, isHeader: Boolean) {
   Box(
-    Modifier.weight(weight)
-      .height(40.dp) // 略微增加高度以匹配之前的风格
-      .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-    Alignment.Center,
+    modifier =
+      Modifier.weight(weight)
+        .height(40.dp)
+        .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
+    contentAlignment = Alignment.Center,
   ) {
     Text(
       text = text,

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomViewModel.kt
@@ -7,12 +7,20 @@ import cn.edu.ubaa.model.dto.ClassroomInfo
 import cn.edu.ubaa.model.dto.ClassroomQueryResponse
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
-/** 教室查询 UI 状态密封类。 */
+internal const val ALL_BUILDINGS = "\u5168\u90e8"
+private const val UNKNOWN_ERROR = "\u672a\u77e5\u9519\u8bef"
+
 sealed class ClassroomUiState {
   object Idle : ClassroomUiState()
 
@@ -23,63 +31,75 @@ sealed class ClassroomUiState {
   data class Error(val message: String) : ClassroomUiState()
 }
 
-/** 教室查询模块的 ViewModel。 负责校区选择、日期选择以及在结果中进行模糊搜索过滤。 */
 class ClassroomViewModel(private val api: ClassroomApi = ClassroomApi()) : ViewModel() {
   private val _uiState = MutableStateFlow<ClassroomUiState>(ClassroomUiState.Idle)
-  /** 核心查询状态流。 */
   val uiState: StateFlow<ClassroomUiState> = _uiState.asStateFlow()
 
-  private val _xqid = MutableStateFlow(1) // 1: 学院路, 2: 沙河, 3: 杭州
-  /** 当前选中的校区 ID。 */
+  private val _xqid = MutableStateFlow(1)
   val xqid: StateFlow<Int> = _xqid.asStateFlow()
 
   private val _date = MutableStateFlow(getCurrentDate())
-  /** 当前选中的查询日期。 */
   val date: StateFlow<String> = _date.asStateFlow()
 
   private val _searchQuery = MutableStateFlow("")
-  /** 当前的搜索关键字流。 */
   val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
 
-  /** 根据搜索关键字过滤后的教室数据流。 自动响应 uiState 和 searchQuery 的变化。 */
-  val filteredData: StateFlow<Map<String, List<ClassroomInfo>>> =
-    combine(_uiState, _searchQuery) { state, query ->
+  private val _selectedBuilding = MutableStateFlow(ALL_BUILDINGS)
+  val selectedBuilding: StateFlow<String> = _selectedBuilding.asStateFlow()
+
+  val availableBuildings: StateFlow<List<String>> =
+    _uiState
+      .map { state ->
         if (state is ClassroomUiState.Success) {
-          val allData = state.data.d.list
-          if (query.isBlank()) allData
-          else
-            allData
-              .mapValues { (_, list) -> list.filter { it.name.contains(query, true) } }
-              .filter { (building, list) -> building.contains(query, true) || list.isNotEmpty() }
-        } else emptyMap()
+          buildingOptionsFrom(state.data.d.list)
+        } else {
+          listOf(ALL_BUILDINGS)
+        }
+      }
+      .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf(ALL_BUILDINGS))
+
+  val filteredData: StateFlow<Map<String, List<ClassroomInfo>>> =
+    combine(_uiState, _searchQuery, _selectedBuilding) { state, query, building ->
+        if (state is ClassroomUiState.Success) {
+          filterClassroomData(state.data.d.list, query, building)
+        } else {
+          emptyMap()
+        }
       }
       .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
 
-  /** 更新搜索关键字。 */
   fun setSearchQuery(query: String) {
     _searchQuery.value = query
   }
 
-  /** 切换校区并自动重新查询。 */
+  fun setSelectedBuilding(building: String) {
+    _selectedBuilding.value = building
+  }
+
   fun setXqid(id: Int) {
     _xqid.value = id
+    _selectedBuilding.value = ALL_BUILDINGS
     query()
   }
 
-  /** 切换日期并自动重新查询。 */
   fun setDate(date: String) {
     _date.value = date
     query()
   }
 
-  /** 执行查询动作。 */
   fun query() {
     viewModelScope.launch {
       _uiState.value = ClassroomUiState.Loading
       api
         .queryClassrooms(_xqid.value, _date.value)
-        .onSuccess { _uiState.value = ClassroomUiState.Success(it) }
-        .onFailure { _uiState.value = ClassroomUiState.Error(it.message ?: "未知错误") }
+        .onSuccess { response ->
+          if (_selectedBuilding.value != ALL_BUILDINGS &&
+            _selectedBuilding.value !in response.d.list.keys) {
+            _selectedBuilding.value = ALL_BUILDINGS
+          }
+          _uiState.value = ClassroomUiState.Success(response)
+        }
+        .onFailure { _uiState.value = ClassroomUiState.Error(it.message ?: UNKNOWN_ERROR) }
     }
   }
 
@@ -88,4 +108,134 @@ class ClassroomViewModel(private val api: ClassroomApi = ClassroomApi()) : ViewM
     val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
     return "${now.year}-${now.monthNumber.toString().padStart(2, '0')}-${now.dayOfMonth.toString().padStart(2, '0')}"
   }
+}
+
+internal fun filterClassroomData(
+  allData: Map<String, List<ClassroomInfo>>,
+  query: String,
+  selectedBuilding: String,
+): Map<String, List<ClassroomInfo>> {
+  val buildingFiltered =
+    if (selectedBuilding == ALL_BUILDINGS) {
+      allData
+    } else {
+      allData.filterKeys { it == selectedBuilding }
+    }
+
+  if (query.isBlank()) return buildingFiltered
+
+  return buildingFiltered
+    .mapValues { (_, list) -> list.filter { it.name.contains(query, ignoreCase = true) } }
+    .filterValues { it.isNotEmpty() }
+}
+
+internal fun buildingOptionsFrom(allData: Map<String, List<ClassroomInfo>>): List<String> {
+  return listOf(ALL_BUILDINGS) + sortBuildings(allData)
+}
+
+internal fun sortBuildings(allData: Map<String, List<ClassroomInfo>>): List<String> {
+  val analysis = analyzeBuildingFloorIds(allData)
+  return if (analysis.canUseFloorIdOrdering) {
+    analysis.entries
+      .sortedWith(
+        compareBy<BuildingFloorAnalysisEntry> { it.floorId }
+          .thenComparator { left, right -> naturalCompare(left.name, right.name) }
+      )
+      .map { it.name }
+  } else {
+    allData.keys.sortedWith(::naturalCompare)
+  }
+}
+
+internal fun analyzeBuildingFloorIds(
+  allData: Map<String, List<ClassroomInfo>>
+): BuildingFloorAnalysis {
+  val entries =
+    allData.map { (building, classrooms) ->
+      val floorIds = classrooms.map { it.floorid.trim() }.filter { it.isNotEmpty() }.toSet()
+      BuildingFloorAnalysisEntry(
+        name = building,
+        floorIds = floorIds,
+        floorId = floorIds.singleOrNull(),
+      )
+    }
+
+  val canUseFloorIdOrdering =
+    entries.isNotEmpty() &&
+      entries.all { it.floorIds.size == 1 && it.floorId != null } &&
+      entries.mapNotNull { it.floorId }.distinct().size == entries.size
+
+  return BuildingFloorAnalysis(entries = entries, canUseFloorIdOrdering = canUseFloorIdOrdering)
+}
+
+internal data class BuildingFloorAnalysis(
+  val entries: List<BuildingFloorAnalysisEntry>,
+  val canUseFloorIdOrdering: Boolean,
+)
+
+internal data class BuildingFloorAnalysisEntry(
+  val name: String,
+  val floorIds: Set<String>,
+  val floorId: String?,
+)
+
+internal fun naturalCompare(left: String, right: String): Int {
+  val leftParts = splitNaturalParts(left)
+  val rightParts = splitNaturalParts(right)
+  val maxSize = maxOf(leftParts.size, rightParts.size)
+  for (index in 0 until maxSize) {
+    val leftPart = leftParts.getOrNull(index) ?: return -1
+    val rightPart = rightParts.getOrNull(index) ?: return 1
+    val result =
+      when {
+        leftPart is NaturalPart.Number && rightPart is NaturalPart.Number ->
+          leftPart.value.compareTo(rightPart.value)
+        leftPart is NaturalPart.Text && rightPart is NaturalPart.Text ->
+          leftPart.value.compareTo(rightPart.value)
+        leftPart is NaturalPart.Number -> -1
+        else -> 1
+      }
+    if (result != 0) return result
+  }
+  return 0
+}
+
+internal fun splitNaturalParts(value: String): List<NaturalPart> {
+  if (value.isEmpty()) return emptyList()
+
+  val parts = mutableListOf<NaturalPart>()
+  val buffer = StringBuilder()
+  var digitMode = value.first().isDigit()
+
+  fun flush() {
+    if (buffer.isEmpty()) return
+    val text = buffer.toString()
+    parts +=
+      if (digitMode) {
+        NaturalPart.Number(text.toIntOrNull() ?: Int.MAX_VALUE)
+      } else {
+        NaturalPart.Text(text)
+      }
+    buffer.clear()
+  }
+
+  value.forEach { char ->
+    val isDigit = char.isDigit()
+    if (buffer.isNotEmpty() && isDigit != digitMode) {
+      flush()
+      digitMode = isDigit
+    } else if (buffer.isEmpty()) {
+      digitMode = isDigit
+    }
+    buffer.append(char)
+  }
+  flush()
+
+  return parts
+}
+
+internal sealed interface NaturalPart {
+  data class Number(val value: Int) : NaturalPart
+
+  data class Text(val value: String) : NaturalPart
 }

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomViewModelTest.kt
@@ -1,0 +1,116 @@
+package cn.edu.ubaa.ui.screens.classroom
+
+import cn.edu.ubaa.model.dto.ClassroomInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClassroomViewModelTest {
+
+  private val classroomData =
+    linkedMapOf(
+      "\u4e09\u53f7\u697c" to
+        listOf(
+          ClassroomInfo(id = "1", floorid = "1J03", name = "3-101", kxsds = "1,2,3"),
+          ClassroomInfo(id = "2", floorid = "1J03", name = "3-201", kxsds = "1,2,3"),
+        ),
+      "\u4e3b\u697c" to
+        listOf(
+          ClassroomInfo(id = "3", floorid = "1J07", name = "\u4e3b\u697c-201", kxsds = "4,5,6")
+        ),
+    )
+
+  @Test
+  fun shouldBuildOptionsFromReturnedBuildings() {
+    val options = buildingOptionsFrom(classroomData)
+
+    assertEquals(listOf(ALL_BUILDINGS, "\u4e09\u53f7\u697c", "\u4e3b\u697c"), options)
+  }
+
+  @Test
+  fun shouldFilterBySelectedBuildingBeforeSearchQuery() {
+    val filtered =
+      filterClassroomData(classroomData, query = "", selectedBuilding = "\u4e3b\u697c")
+
+    assertEquals(listOf("\u4e3b\u697c"), filtered.keys.toList())
+    assertEquals(1, filtered["\u4e3b\u697c"]?.size)
+  }
+
+  @Test
+  fun shouldKeepBuildingMatchWhenSearchingInsideSelectedBuilding() {
+    val filtered =
+      filterClassroomData(
+        classroomData,
+        query = "\u65b0\u4e3b\u697c",
+        selectedBuilding = "\u4e3b\u697c",
+      )
+
+    assertTrue(filtered.isEmpty())
+  }
+
+  @Test
+  fun shouldFilterByClassroomNameAcrossAllBuildings() {
+    val filtered = filterClassroomData(classroomData, query = "201", selectedBuilding = ALL_BUILDINGS)
+
+    assertEquals(listOf("\u4e09\u53f7\u697c", "\u4e3b\u697c"), filtered.keys.toList())
+    assertEquals(listOf("3-201"), filtered["\u4e09\u53f7\u697c"]?.map { it.name })
+    assertEquals(listOf("\u4e3b\u697c-201"), filtered["\u4e3b\u697c"]?.map { it.name })
+  }
+
+  @Test
+  fun shouldUseFloorIdOrderingWhenEveryBuildingHasSingleStringFloorId() {
+    val ordered =
+      sortBuildings(
+        linkedMapOf(
+          "\u4e09\u53f7\u697c" to
+            listOf(ClassroomInfo(id = "1", floorid = "2J03", name = "3-101", kxsds = "1,2")),
+          "\u6559\u96f6\u697c" to
+            listOf(ClassroomInfo(id = "2", floorid = "2J00", name = "J0-101", kxsds = "1,2")),
+          "\u4e00\u53f7\u6559\u5b66\u697c" to
+            listOf(ClassroomInfo(id = "3", floorid = "2J01", name = "J1-101", kxsds = "1,2")),
+          "\u6c99\u6cb3\u6821\u533a\u4e8c\u53f7\u697c" to
+            listOf(ClassroomInfo(id = "4", floorid = "2Z02", name = "SH2-101", kxsds = "1,2")),
+        )
+      )
+
+    assertEquals(
+      listOf("\u6559\u96f6\u697c", "\u4e00\u53f7\u6559\u5b66\u697c", "\u4e09\u53f7\u697c", "\u6c99\u6cb3\u6821\u533a\u4e8c\u53f7\u697c"),
+      ordered,
+    )
+  }
+
+  @Test
+  fun shouldFallbackToNaturalOrderingWhenBuildingHasMultipleFloorIds() {
+    val ordered =
+      sortBuildings(
+        linkedMapOf(
+          "10\u53f7\u697c" to
+            listOf(
+              ClassroomInfo(id = "1", floorid = "10", name = "10-101", kxsds = "1,2"),
+              ClassroomInfo(id = "2", floorid = "11", name = "10-102", kxsds = "1,2"),
+            ),
+          "2\u53f7\u697c" to
+            listOf(ClassroomInfo(id = "3", floorid = "2", name = "2-101", kxsds = "1,2")),
+          "\u6559\u96f6\u697c" to
+            listOf(ClassroomInfo(id = "4", floorid = "0", name = "J0-101", kxsds = "1,2")),
+        )
+      )
+
+    assertEquals(listOf("2\u53f7\u697c", "10\u53f7\u697c", "\u6559\u96f6\u697c"), ordered)
+  }
+
+  @Test
+  fun shouldReportFloorIdValidationFailureForDuplicateBuildingFloorIds() {
+    val analysis =
+      analyzeBuildingFloorIds(
+        linkedMapOf(
+          "\u4e00\u53f7\u697c" to
+            listOf(ClassroomInfo(id = "1", floorid = "2J01", name = "1-101", kxsds = "1,2")),
+          "\u4e8c\u53f7\u697c" to
+            listOf(ClassroomInfo(id = "2", floorid = "2J01", name = "2-101", kxsds = "1,2")),
+        )
+      )
+
+    assertTrue(!analysis.canUseFloorIdOrdering)
+  }
+}


### PR DESCRIPTION
## 变更说明

本次修改主要优化空教室查询页面的使用体验，调整了楼栋筛选和搜索逻辑。

## 主要改动

- 在页面头部新增楼栋下拉菜单
- 楼栋选项根据当前校区的查询结果动态生成
- 搜索框调整为仅搜索教室名称，不再搜索楼栋名称
- 搜索框提示文案改为“搜索教室”
- 楼栋下拉按 `floorid` 字符串升序排序，使顺序更接近智慧北航中的展示方式
- 保留异常数据兜底逻辑：当 `floorid` 不稳定或冲突时，回退为名称自然排序

## 交互效果

- 用户先选择校区
- 再通过下拉菜单选择楼栋
- 搜索仅在当前楼栋筛选结果内按教室名称进行匹配
- 不再出现“只显示楼栋标题、不显示教室”的搜索结果

## 测试情况

已通过以下测试：

```bash
./gradlew :composeApp:jvmTest --tests cn.edu.ubaa.ui.screens.classroom.ClassroomViewModelTest
```
## 补充说明
本次 PR 仅包含空教室功能相关修改，不包含本地开发环境适配、Redis/SQLite 回退、代理配置等本地运行性调整。

## 截图
- 空教室页面新增楼栋下拉
<img width="1179" height="846" alt="image" src="https://github.com/user-attachments/assets/7340fbcf-b29e-47b5-aa81-3bb303032f87" />

- 沙河校区楼栋顺序展示
<img width="1179" height="846" alt="image" src="https://github.com/user-attachments/assets/2f333f05-c702-48dc-b97f-12efa5d8c300" />

- 楼栋筛选与教室搜索联动效果
搜索范围已调整为“仅搜索教室名称”，不再直接匹配楼栋名称。  
当楼栋为“全部”时，会在当前校区的全部教室结果中搜索；当选择具体楼栋时，只在该楼栋下搜索教室。

**全部楼栋时的搜索效果**

<img width="1179" height="843" alt="全部楼栋时搜索全部教室结果" src="https://github.com/user-attachments/assets/66d24669-0558-490f-a381-1c56a094fda8" />

*图 1：选择“全部”时，搜索会在当前校区的全部教室结果中进行匹配。*

**选择特定楼栋时的搜索效果**

<img width="1179" height="843" alt="选择特定楼栋时仅搜索该楼栋教室结果" src="https://github.com/user-attachments/assets/b59f2a67-a035-42d0-8259-6c271601bd24" />

*图 2：选择具体楼栋后，搜索范围收敛到该楼栋下的教室结果。*