### PR TITLE
优化空教室楼栋按钮的排序逻辑

### DIFF
--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/classroom/ClassroomViewModel.kt
@@ -50,7 +50,7 @@ class ClassroomViewModel(private val api: ClassroomApi = ClassroomApi()) : ViewM
     _uiState
       .map { state ->
         if (state is ClassroomUiState.Success) {
-          state.data.d.list.keys.toList()
+          sortBuildings(state.data.d.list)
         } else {
           emptyList()
         }
@@ -123,4 +123,111 @@ class ClassroomViewModel(private val api: ClassroomApi = ClassroomApi()) : ViewM
     val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
     return "${now.year}-${now.monthNumber.toString().padStart(2, '0')}-${now.dayOfMonth.toString().padStart(2, '0')}"
   }
+}
+
+internal fun sortBuildings(allData: Map<String, List<ClassroomInfo>>): List<String> {
+  val analysis = analyzeBuildingFloorIds(allData)
+  return if (analysis.canUseFloorIdOrdering) {
+    analysis.entries
+      .sortedWith(
+        compareBy<BuildingFloorAnalysisEntry> { it.floorId }
+          .thenComparator { left, right -> naturalCompare(left.name, right.name) }
+      )
+      .map { it.name }
+  } else {
+    allData.keys.sortedWith(::naturalCompare)
+  }
+}
+
+internal fun analyzeBuildingFloorIds(
+  allData: Map<String, List<ClassroomInfo>>
+): BuildingFloorAnalysis {
+  val entries =
+    allData.map { (building, classrooms) ->
+      val floorIds = classrooms.map { it.floorid.trim() }.filter { it.isNotEmpty() }.toSet()
+      BuildingFloorAnalysisEntry(
+        name = building,
+        floorIds = floorIds,
+        floorId = floorIds.singleOrNull(),
+      )
+    }
+
+  val canUseFloorIdOrdering =
+    entries.isNotEmpty() &&
+      entries.all { it.floorIds.size == 1 && it.floorId != null } &&
+      entries.mapNotNull { it.floorId }.distinct().size == entries.size
+
+  return BuildingFloorAnalysis(entries = entries, canUseFloorIdOrdering = canUseFloorIdOrdering)
+}
+
+internal data class BuildingFloorAnalysis(
+  val entries: List<BuildingFloorAnalysisEntry>,
+  val canUseFloorIdOrdering: Boolean,
+)
+
+internal data class BuildingFloorAnalysisEntry(
+  val name: String,
+  val floorIds: Set<String>,
+  val floorId: String?,
+)
+
+internal fun naturalCompare(left: String, right: String): Int {
+  val leftParts = splitNaturalParts(left)
+  val rightParts = splitNaturalParts(right)
+  val maxSize = maxOf(leftParts.size, rightParts.size)
+  for (index in 0 until maxSize) {
+    val leftPart = leftParts.getOrNull(index) ?: return -1
+    val rightPart = rightParts.getOrNull(index) ?: return 1
+    val result =
+      when {
+        leftPart is NaturalPart.Number && rightPart is NaturalPart.Number ->
+          leftPart.value.compareTo(rightPart.value)
+        leftPart is NaturalPart.Text && rightPart is NaturalPart.Text ->
+          leftPart.value.compareTo(rightPart.value)
+        leftPart is NaturalPart.Number -> -1
+        else -> 1
+      }
+    if (result != 0) return result
+  }
+  return 0
+}
+
+internal fun splitNaturalParts(value: String): List<NaturalPart> {
+  if (value.isEmpty()) return emptyList()
+
+  val parts = mutableListOf<NaturalPart>()
+  val buffer = StringBuilder()
+  var digitMode = value.first().isDigit()
+
+  fun flush() {
+    if (buffer.isEmpty()) return
+    val text = buffer.toString()
+    parts +=
+      if (digitMode) {
+        NaturalPart.Number(text.toIntOrNull() ?: Int.MAX_VALUE)
+      } else {
+        NaturalPart.Text(text)
+      }
+    buffer.clear()
+  }
+
+  value.forEach { char ->
+    val isDigit = char.isDigit()
+    if (buffer.isNotEmpty() && isDigit != digitMode) {
+      flush()
+      digitMode = isDigit
+    } else if (buffer.isEmpty()) {
+      digitMode = isDigit
+    }
+    buffer.append(char)
+  }
+  flush()
+
+  return parts
+}
+
+internal sealed interface NaturalPart {
+  data class Number(val value: Int) : NaturalPart
+
+  data class Text(val value: String) : NaturalPart
 }

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/ClassroomViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/ClassroomViewModelTest.kt
@@ -5,10 +5,13 @@ import cn.edu.ubaa.model.dto.ClassroomData
 import cn.edu.ubaa.model.dto.ClassroomInfo
 import cn.edu.ubaa.model.dto.ClassroomQueryResponse
 import cn.edu.ubaa.ui.screens.classroom.ClassroomViewModel
+import cn.edu.ubaa.ui.screens.classroom.analyzeBuildingFloorIds
+import cn.edu.ubaa.ui.screens.classroom.sortBuildings
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -36,6 +39,65 @@ class ClassroomViewModelTest {
     assertNull(viewModel.selectedBuilding.value)
     assertEquals(listOf("教学楼A", "教学楼B"), viewModel.availableBuildings.value)
     assertEquals(listOf("教学楼A", "教学楼B"), viewModel.filteredData.value.keys.toList())
+  }
+
+  @Test
+  fun `buildings are ordered by floorid string when each building has one unique floorid`() {
+    val ordered =
+      sortBuildings(
+        linkedMapOf(
+          "三号教学楼" to
+            listOf(ClassroomInfo(id = "1", floorid = "2J03", name = "J3-101", kxsds = "1,2")),
+          "教零楼" to
+            listOf(ClassroomInfo(id = "2", floorid = "2J00", name = "J0-101", kxsds = "1,2")),
+          "一号教学楼" to
+            listOf(ClassroomInfo(id = "3", floorid = "2J01", name = "J1-101", kxsds = "1,2")),
+          "沙河校区二号楼" to
+            listOf(ClassroomInfo(id = "4", floorid = "2Z02", name = "SH2-101", kxsds = "1,2")),
+          "沙河校区三号楼" to
+            listOf(ClassroomInfo(id = "5", floorid = "2Z03", name = "SH3-101", kxsds = "1,2")),
+        )
+      )
+
+    assertEquals(
+      listOf("教零楼", "一号教学楼", "三号教学楼", "沙河校区二号楼", "沙河校区三号楼"),
+      ordered,
+    )
+  }
+
+  @Test
+  fun `falls back to natural ordering when a building has multiple floorids`() {
+    val ordered =
+      sortBuildings(
+        linkedMapOf(
+          "10号楼" to
+            listOf(
+              ClassroomInfo(id = "1", floorid = "10", name = "10-101", kxsds = "1,2"),
+              ClassroomInfo(id = "2", floorid = "11", name = "10-102", kxsds = "1,2"),
+            ),
+          "2号楼" to
+            listOf(ClassroomInfo(id = "3", floorid = "2", name = "2-101", kxsds = "1,2")),
+          "教零楼" to
+            listOf(ClassroomInfo(id = "4", floorid = "0", name = "J0-101", kxsds = "1,2")),
+        )
+      )
+
+    assertEquals(listOf("2号楼", "10号楼", "教零楼"), ordered)
+  }
+
+  @Test
+  fun `falls back when duplicate floorids exist across buildings`() {
+    val analysis =
+      analyzeBuildingFloorIds(
+        linkedMapOf(
+          "一号楼" to
+            listOf(ClassroomInfo(id = "1", floorid = "2J01", name = "1-101", kxsds = "1,2")),
+          "二号楼" to
+            listOf(ClassroomInfo(id = "2", floorid = "2J01", name = "2-101", kxsds = "1,2")),
+        )
+      )
+
+    assertTrue(!analysis.canUseFloorIdOrdering)
   }
 
   @Test


### PR DESCRIPTION
## 变更说明
保留当前空教室页面“搜索框下方横向滚动楼栋按钮”的交互，仅优化楼栋按钮的排序逻辑。

## 问题说明
同意空教室楼栋使用横向滑动选择的交互逻辑，但是目前存在顺序杂乱的问题。

## 改动内容
- 将楼栋列表优先按唯一 `floorid` 的字符串升序排序。
- 当 `floorid` 缺失、同楼栋存在多个 `floorid` 或不同楼栋 `floorid` 冲突时，回退为楼栋名称自然排序

## 效果
例如沙河校区楼栋顺序，修正前：
<img width="1179" height="846" alt="image" src="https://github.com/user-attachments/assets/769a6cec-e878-4d32-a91c-c9d0af2d6a75" />

修正后，与智慧bh顺序一致：
<img width="1179" height="846" alt="image" src="https://github.com/user-attachments/assets/6b4db053-4ebc-4ec4-93db-ca0f5c424677" />


## 待解决的问题
-  #26 中提到的搜索问题依然没有解决。如果直接搜索楼栋名称，仅显示楼栋名称，没有交互意义。既然楼栋数量较少，直接选择能够满足用户需求。所以仍然建议将逻辑改为：搜索仅针对当前选择下楼栋的教室名称进行。
- 目前新版更新后 readme 网页版跳转仍然旧版。

这个软件已经推荐给了室友和身边的伙伴，得到了一致好评。（在被窝里签到真的很爽）希望能够一起把它开发的越来越好，造福更多buaa同学！