### PR TITLE
feat(schedule): show week date range above the weekly schedule

### DIFF
--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
@@ -25,7 +25,7 @@ internal fun Week.headerDayLabels(): List<ScheduleHeaderDayLabel> {
   return defaults.mapIndexed { index, default ->
     ScheduleHeaderDayLabel(
         weekdayLabel = default.weekdayLabel,
-        dateLabel = parsedStart.plus(DatePeriod(days = index)).toMonthDayLabel(),
+        dateLabel = parsedStart.plus(DatePeriod(days = index)).toShortMonthDayLabel(),
     )
   }
 }
@@ -45,6 +45,6 @@ private fun parseWeekBoundaryDate(raw: String?): LocalDate? {
   return runCatching { LocalDate(yearText.toInt(), monthText.toInt(), dayText.toInt()) }.getOrNull()
 }
 
-private fun LocalDate.toMonthDayLabel(): String = "${month.ordinal + 1}月${day}日"
+private fun LocalDate.toShortMonthDayLabel(): String = "${month.ordinal + 1}-${day}"
 
 private val FLEXIBLE_DATE_PATTERN = Regex("""(\d{4})\D+(\d{1,2})\D+(\d{1,2})""")

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
@@ -16,7 +16,9 @@ internal fun defaultScheduleHeaderDayLabels(): List<ScheduleHeaderDayLabel> =
     }
 
 internal fun Week.headerDayLabels(): List<ScheduleHeaderDayLabel> {
-  val parsedStart = runCatching { LocalDate.parse(startDate.trim()) }.getOrNull()
+  val parsedStart =
+      parseWeekBoundaryDate(startDate)
+          ?: parseWeekBoundaryDate(endDate)?.plus(DatePeriod(days = -6))
   val defaults = defaultScheduleHeaderDayLabels()
   if (parsedStart == null) return defaults
 
@@ -28,4 +30,21 @@ internal fun Week.headerDayLabels(): List<ScheduleHeaderDayLabel> {
   }
 }
 
+private fun parseWeekBoundaryDate(raw: String?): LocalDate? {
+  val normalized = raw?.trim().orEmpty()
+  if (normalized.isEmpty()) return null
+
+  runCatching { LocalDate.parse(normalized) }
+      .getOrNull()
+      ?.let {
+        return it
+      }
+
+  val match = FLEXIBLE_DATE_PATTERN.find(normalized) ?: return null
+  val (yearText, monthText, dayText) = match.destructured
+  return runCatching { LocalDate(yearText.toInt(), monthText.toInt(), dayText.toInt()) }.getOrNull()
+}
+
 private fun LocalDate.toMonthDayLabel(): String = "${month.ordinal + 1}月${day}日"
+
+private val FLEXIBLE_DATE_PATTERN = Regex("""(\d{4})\D+(\d{1,2})\D+(\d{1,2})""")

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
@@ -1,0 +1,25 @@
+package cn.edu.ubaa.ui.screens.schedule
+
+import cn.edu.ubaa.model.dto.Week
+import kotlinx.datetime.LocalDate
+
+internal fun Week.dateRangeLabel(): String? = formatWeekDateRange(startDate, endDate)
+
+internal fun formatWeekDateRange(startDate: String?, endDate: String?): String? {
+  val safeStart = startDate?.trim().orEmpty()
+  val safeEnd = endDate?.trim().orEmpty()
+  if (safeStart.isEmpty() || safeEnd.isEmpty()) return null
+
+  val parsedStart = runCatching { LocalDate.parse(safeStart) }.getOrNull()
+  val parsedEnd = runCatching { LocalDate.parse(safeEnd) }.getOrNull()
+
+  return when {
+    parsedStart != null && parsedEnd != null && parsedStart.year == parsedEnd.year ->
+        "${parsedStart.monthValueText()}月${parsedStart.day}日 - ${parsedEnd.monthValueText()}月${parsedEnd.day}日"
+    parsedStart != null && parsedEnd != null ->
+        "${parsedStart.year}年${parsedStart.monthValueText()}月${parsedStart.day}日 - ${parsedEnd.year}年${parsedEnd.monthValueText()}月${parsedEnd.day}日"
+    else -> "$safeStart - $safeEnd"
+  }
+}
+
+private fun LocalDate.monthValueText(): Int = month.ordinal + 1

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabels.kt
@@ -1,25 +1,31 @@
 package cn.edu.ubaa.ui.screens.schedule
 
 import cn.edu.ubaa.model.dto.Week
+import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
 
-internal fun Week.dateRangeLabel(): String? = formatWeekDateRange(startDate, endDate)
+internal data class ScheduleHeaderDayLabel(
+    val weekdayLabel: String,
+    val dateLabel: String? = null,
+)
 
-internal fun formatWeekDateRange(startDate: String?, endDate: String?): String? {
-  val safeStart = startDate?.trim().orEmpty()
-  val safeEnd = endDate?.trim().orEmpty()
-  if (safeStart.isEmpty() || safeEnd.isEmpty()) return null
+internal fun defaultScheduleHeaderDayLabels(): List<ScheduleHeaderDayLabel> =
+    listOf("周一", "周二", "周三", "周四", "周五", "周六", "周日").map {
+      ScheduleHeaderDayLabel(weekdayLabel = it)
+    }
 
-  val parsedStart = runCatching { LocalDate.parse(safeStart) }.getOrNull()
-  val parsedEnd = runCatching { LocalDate.parse(safeEnd) }.getOrNull()
+internal fun Week.headerDayLabels(): List<ScheduleHeaderDayLabel> {
+  val parsedStart = runCatching { LocalDate.parse(startDate.trim()) }.getOrNull()
+  val defaults = defaultScheduleHeaderDayLabels()
+  if (parsedStart == null) return defaults
 
-  return when {
-    parsedStart != null && parsedEnd != null && parsedStart.year == parsedEnd.year ->
-        "${parsedStart.monthValueText()}月${parsedStart.day}日 - ${parsedEnd.monthValueText()}月${parsedEnd.day}日"
-    parsedStart != null && parsedEnd != null ->
-        "${parsedStart.year}年${parsedStart.monthValueText()}月${parsedStart.day}日 - ${parsedEnd.year}年${parsedEnd.monthValueText()}月${parsedEnd.day}日"
-    else -> "$safeStart - $safeEnd"
+  return defaults.mapIndexed { index, default ->
+    ScheduleHeaderDayLabel(
+        weekdayLabel = default.weekdayLabel,
+        dateLabel = parsedStart.plus(DatePeriod(days = index)).toMonthDayLabel(),
+    )
   }
 }
 
-private fun LocalDate.monthValueText(): Int = month.ordinal + 1
+private fun LocalDate.toMonthDayLabel(): String = "${month.ordinal + 1}月${day}日"

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleScreen.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleScreen.kt
@@ -65,11 +65,13 @@ fun ScheduleScreen(
 ) {
   var showWeekSelector by remember { mutableStateOf(false) }
   val currentWeekIndex = weeks.indexOf(selectedWeek)
+  val selectedWeekDateRange = selectedWeek?.dateRangeLabel()
 
   Scaffold(
       topBar = {
         ScheduleTopAppBar(
             title = selectedWeek?.name ?: "选择周次",
+            subtitle = selectedWeekDateRange,
             onNavigateBack = onNavigateBack,
             onPreviousClick = {
               if (currentWeekIndex > 0) onWeekSelected(weeks[currentWeekIndex - 1])
@@ -142,6 +144,7 @@ fun ScheduleScreen(
 @Composable
 private fun ScheduleTopAppBar(
     title: String,
+    subtitle: String?,
     onNavigateBack: () -> Unit,
     onPreviousClick: () -> Unit,
     isPreviousEnabled: Boolean,
@@ -150,14 +153,14 @@ private fun ScheduleTopAppBar(
     onTitleClick: () -> Unit,
 ) {
   CenterAlignedTopAppBar(
-      expandedHeight = 56.dp,
+      expandedHeight = 64.dp,
       navigationIcon = {
         IconButton(onClick = onNavigateBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "返回") }
       },
       title = {
-        Row(
+        Column(
             modifier = Modifier.clickable(onClick = onTitleClick),
-            verticalAlignment = Alignment.CenterVertically,
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
           Text(
               text = title,
@@ -165,6 +168,15 @@ private fun ScheduleTopAppBar(
               maxLines = 1,
               overflow = TextOverflow.Ellipsis,
           )
+          subtitle?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+          }
         }
       },
       actions = {

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleScreen.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleScreen.kt
@@ -65,13 +65,12 @@ fun ScheduleScreen(
 ) {
   var showWeekSelector by remember { mutableStateOf(false) }
   val currentWeekIndex = weeks.indexOf(selectedWeek)
-  val selectedWeekDateRange = selectedWeek?.dateRangeLabel()
+  val headerDayLabels = selectedWeek?.headerDayLabels() ?: defaultScheduleHeaderDayLabels()
 
   Scaffold(
       topBar = {
         ScheduleTopAppBar(
             title = selectedWeek?.name ?: "选择周次",
-            subtitle = selectedWeekDateRange,
             onNavigateBack = onNavigateBack,
             onPreviousClick = {
               if (currentWeekIndex > 0) onWeekSelected(weeks[currentWeekIndex - 1])
@@ -111,7 +110,11 @@ fun ScheduleScreen(
           }
         }
         weeklySchedule != null && selectedWeek != null -> {
-          WeeklyScheduleView(schedule = weeklySchedule, onCourseClick = onCourseClick)
+          WeeklyScheduleView(
+              schedule = weeklySchedule,
+              headerDayLabels = headerDayLabels,
+              onCourseClick = onCourseClick,
+          )
         }
         else -> {
           Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -144,7 +147,6 @@ fun ScheduleScreen(
 @Composable
 private fun ScheduleTopAppBar(
     title: String,
-    subtitle: String?,
     onNavigateBack: () -> Unit,
     onPreviousClick: () -> Unit,
     isPreviousEnabled: Boolean,
@@ -153,14 +155,14 @@ private fun ScheduleTopAppBar(
     onTitleClick: () -> Unit,
 ) {
   CenterAlignedTopAppBar(
-      expandedHeight = 64.dp,
+      expandedHeight = 56.dp,
       navigationIcon = {
         IconButton(onClick = onNavigateBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "返回") }
       },
       title = {
-        Column(
+        Row(
             modifier = Modifier.clickable(onClick = onTitleClick),
-            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
           Text(
               text = title,
@@ -168,15 +170,6 @@ private fun ScheduleTopAppBar(
               maxLines = 1,
               overflow = TextOverflow.Ellipsis,
           )
-          subtitle?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-          }
         }
       },
       actions = {
@@ -239,17 +232,17 @@ private fun WeekSelectionSheet(
 @Composable
 private fun WeeklyScheduleView(
     schedule: WeeklySchedule,
+    headerDayLabels: List<ScheduleHeaderDayLabel>,
     onCourseClick: (CourseClass) -> Unit,
     modifier: Modifier = Modifier,
 ) {
   val totalPeriods = maxOf(12, schedule.arrangedList.maxOfOrNull { it.endSection ?: 0 } ?: 0)
   val timeLabels = (1..totalPeriods).map { it.toString() }
-  val dayLabels = listOf("周一", "周二", "周三", "周四", "周五", "周六", "周日")
   val rowHeight: Dp = 64.dp
   val scrollState = rememberScrollState()
 
   Column(modifier = modifier.padding(horizontal = 8.dp)) {
-    HeaderRow(dayLabels)
+    HeaderRow(headerDayLabels)
     Spacer(modifier = Modifier.height(4.dp))
     Row(
         modifier =
@@ -268,12 +261,22 @@ private fun WeeklyScheduleView(
 
 /** 星期标题行。 */
 @Composable
-private fun HeaderRow(dayLabels: List<String>) {
+private fun HeaderRow(dayLabels: List<ScheduleHeaderDayLabel>) {
   Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
     Spacer(modifier = Modifier.width(36.dp))
     dayLabels.forEach {
       Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
-        Text(text = it, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+          Text(text = it.weekdayLabel, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+          it.dateLabel?.let { dateLabel ->
+            Text(
+                text = dateLabel,
+                fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+          }
+        }
       }
     }
   }

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
@@ -40,14 +40,49 @@ class ScheduleDateLabelsTest {
 
   @Test
   fun headerDayLabelsFallsBackToWeekdaysWhenDateParsingFails() {
-    assertEquals(defaultScheduleHeaderDayLabels(), week(startDate = "2026/04/13").headerDayLabels())
+    assertEquals(
+        defaultScheduleHeaderDayLabels(),
+        week(startDate = "invalid", endDate = "still-invalid").headerDayLabels(),
+    )
+  }
+
+  @Test
+  fun headerDayLabelsCanRecoverFromEndDateWhenStartDateIsInvalid() {
+    assertEquals(
+        listOf(
+            ScheduleHeaderDayLabel("周一", "4月13日"),
+            ScheduleHeaderDayLabel("周二", "4月14日"),
+            ScheduleHeaderDayLabel("周三", "4月15日"),
+            ScheduleHeaderDayLabel("周四", "4月16日"),
+            ScheduleHeaderDayLabel("周五", "4月17日"),
+            ScheduleHeaderDayLabel("周六", "4月18日"),
+            ScheduleHeaderDayLabel("周日", "4月19日"),
+        ),
+        week(startDate = "invalid", endDate = "2026-04-19").headerDayLabels(),
+    )
+  }
+
+  @Test
+  fun headerDayLabelsSupportsUnpaddedAndDateTimeFormattedWeekBoundaries() {
+    assertEquals(
+        listOf(
+            ScheduleHeaderDayLabel("周一", "4月13日"),
+            ScheduleHeaderDayLabel("周二", "4月14日"),
+            ScheduleHeaderDayLabel("周三", "4月15日"),
+            ScheduleHeaderDayLabel("周四", "4月16日"),
+            ScheduleHeaderDayLabel("周五", "4月17日"),
+            ScheduleHeaderDayLabel("周六", "4月18日"),
+            ScheduleHeaderDayLabel("周日", "4月19日"),
+        ),
+        week(startDate = "2026-4-13 00:00:00", endDate = "2026-4-19 23:59:59").headerDayLabels(),
+    )
   }
 }
 
-private fun week(startDate: String) =
+private fun week(startDate: String, endDate: String = "2026-04-19") =
     Week(
         startDate = startDate,
-        endDate = "2026-04-19",
+        endDate = endDate,
         term = "2025-2026-2",
         curWeek = false,
         serialNumber = 7,

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
@@ -10,13 +10,13 @@ class ScheduleDateLabelsTest {
   fun headerDayLabelsReturnsWeekdayAndMonthDayForValidStartDate() {
     assertEquals(
         listOf(
-            ScheduleHeaderDayLabel("周一", "4月13日"),
-            ScheduleHeaderDayLabel("周二", "4月14日"),
-            ScheduleHeaderDayLabel("周三", "4月15日"),
-            ScheduleHeaderDayLabel("周四", "4月16日"),
-            ScheduleHeaderDayLabel("周五", "4月17日"),
-            ScheduleHeaderDayLabel("周六", "4月18日"),
-            ScheduleHeaderDayLabel("周日", "4月19日"),
+            ScheduleHeaderDayLabel("周一", "4-13"),
+            ScheduleHeaderDayLabel("周二", "4-14"),
+            ScheduleHeaderDayLabel("周三", "4-15"),
+            ScheduleHeaderDayLabel("周四", "4-16"),
+            ScheduleHeaderDayLabel("周五", "4-17"),
+            ScheduleHeaderDayLabel("周六", "4-18"),
+            ScheduleHeaderDayLabel("周日", "4-19"),
         ),
         week(startDate = "2026-04-13").headerDayLabels(),
     )
@@ -26,13 +26,13 @@ class ScheduleDateLabelsTest {
   fun headerDayLabelsDoesNotIncludeYearWhenWeekCrossesYears() {
     assertEquals(
         listOf(
-            ScheduleHeaderDayLabel("周一", "12月29日"),
-            ScheduleHeaderDayLabel("周二", "12月30日"),
-            ScheduleHeaderDayLabel("周三", "12月31日"),
-            ScheduleHeaderDayLabel("周四", "1月1日"),
-            ScheduleHeaderDayLabel("周五", "1月2日"),
-            ScheduleHeaderDayLabel("周六", "1月3日"),
-            ScheduleHeaderDayLabel("周日", "1月4日"),
+            ScheduleHeaderDayLabel("周一", "12-29"),
+            ScheduleHeaderDayLabel("周二", "12-30"),
+            ScheduleHeaderDayLabel("周三", "12-31"),
+            ScheduleHeaderDayLabel("周四", "1-1"),
+            ScheduleHeaderDayLabel("周五", "1-2"),
+            ScheduleHeaderDayLabel("周六", "1-3"),
+            ScheduleHeaderDayLabel("周日", "1-4"),
         ),
         week(startDate = "2025-12-29").headerDayLabels(),
     )
@@ -50,13 +50,13 @@ class ScheduleDateLabelsTest {
   fun headerDayLabelsCanRecoverFromEndDateWhenStartDateIsInvalid() {
     assertEquals(
         listOf(
-            ScheduleHeaderDayLabel("周一", "4月13日"),
-            ScheduleHeaderDayLabel("周二", "4月14日"),
-            ScheduleHeaderDayLabel("周三", "4月15日"),
-            ScheduleHeaderDayLabel("周四", "4月16日"),
-            ScheduleHeaderDayLabel("周五", "4月17日"),
-            ScheduleHeaderDayLabel("周六", "4月18日"),
-            ScheduleHeaderDayLabel("周日", "4月19日"),
+            ScheduleHeaderDayLabel("周一", "4-13"),
+            ScheduleHeaderDayLabel("周二", "4-14"),
+            ScheduleHeaderDayLabel("周三", "4-15"),
+            ScheduleHeaderDayLabel("周四", "4-16"),
+            ScheduleHeaderDayLabel("周五", "4-17"),
+            ScheduleHeaderDayLabel("周六", "4-18"),
+            ScheduleHeaderDayLabel("周日", "4-19"),
         ),
         week(startDate = "invalid", endDate = "2026-04-19").headerDayLabels(),
     )
@@ -66,13 +66,13 @@ class ScheduleDateLabelsTest {
   fun headerDayLabelsSupportsUnpaddedAndDateTimeFormattedWeekBoundaries() {
     assertEquals(
         listOf(
-            ScheduleHeaderDayLabel("周一", "4月13日"),
-            ScheduleHeaderDayLabel("周二", "4月14日"),
-            ScheduleHeaderDayLabel("周三", "4月15日"),
-            ScheduleHeaderDayLabel("周四", "4月16日"),
-            ScheduleHeaderDayLabel("周五", "4月17日"),
-            ScheduleHeaderDayLabel("周六", "4月18日"),
-            ScheduleHeaderDayLabel("周日", "4月19日"),
+            ScheduleHeaderDayLabel("周一", "4-13"),
+            ScheduleHeaderDayLabel("周二", "4-14"),
+            ScheduleHeaderDayLabel("周三", "4-15"),
+            ScheduleHeaderDayLabel("周四", "4-16"),
+            ScheduleHeaderDayLabel("周五", "4-17"),
+            ScheduleHeaderDayLabel("周六", "4-18"),
+            ScheduleHeaderDayLabel("周日", "4-19"),
         ),
         week(startDate = "2026-4-13 00:00:00", endDate = "2026-4-19 23:59:59").headerDayLabels(),
     )

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
@@ -1,0 +1,31 @@
+package cn.edu.ubaa.ui.screens.schedule
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ScheduleDateLabelsTest {
+
+  @Test
+  fun formatWeekDateRangeReturnsLocalizedMonthDayForSameYear() {
+    assertEquals("4月14日 - 4月20日", formatWeekDateRange("2026-04-14", "2026-04-20"))
+  }
+
+  @Test
+  fun formatWeekDateRangeIncludesYearWhenRangeCrossesYears() {
+    assertEquals(
+        "2026年12月29日 - 2027年1月4日",
+        formatWeekDateRange("2026-12-29", "2027-01-04"),
+    )
+  }
+
+  @Test
+  fun formatWeekDateRangeFallsBackToRawValuesWhenDateParsingFails() {
+    assertEquals("2026/04/14 - 2026/04/20", formatWeekDateRange("2026/04/14", "2026/04/20"))
+  }
+
+  @Test
+  fun formatWeekDateRangeReturnsNullWhenDateIsMissing() {
+    assertNull(formatWeekDateRange("2026-04-14", null))
+  }
+}

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/screens/schedule/ScheduleDateLabelsTest.kt
@@ -1,31 +1,55 @@
 package cn.edu.ubaa.ui.screens.schedule
 
+import cn.edu.ubaa.model.dto.Week
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class ScheduleDateLabelsTest {
 
   @Test
-  fun formatWeekDateRangeReturnsLocalizedMonthDayForSameYear() {
-    assertEquals("4月14日 - 4月20日", formatWeekDateRange("2026-04-14", "2026-04-20"))
-  }
-
-  @Test
-  fun formatWeekDateRangeIncludesYearWhenRangeCrossesYears() {
+  fun headerDayLabelsReturnsWeekdayAndMonthDayForValidStartDate() {
     assertEquals(
-        "2026年12月29日 - 2027年1月4日",
-        formatWeekDateRange("2026-12-29", "2027-01-04"),
+        listOf(
+            ScheduleHeaderDayLabel("周一", "4月13日"),
+            ScheduleHeaderDayLabel("周二", "4月14日"),
+            ScheduleHeaderDayLabel("周三", "4月15日"),
+            ScheduleHeaderDayLabel("周四", "4月16日"),
+            ScheduleHeaderDayLabel("周五", "4月17日"),
+            ScheduleHeaderDayLabel("周六", "4月18日"),
+            ScheduleHeaderDayLabel("周日", "4月19日"),
+        ),
+        week(startDate = "2026-04-13").headerDayLabels(),
     )
   }
 
   @Test
-  fun formatWeekDateRangeFallsBackToRawValuesWhenDateParsingFails() {
-    assertEquals("2026/04/14 - 2026/04/20", formatWeekDateRange("2026/04/14", "2026/04/20"))
+  fun headerDayLabelsDoesNotIncludeYearWhenWeekCrossesYears() {
+    assertEquals(
+        listOf(
+            ScheduleHeaderDayLabel("周一", "12月29日"),
+            ScheduleHeaderDayLabel("周二", "12月30日"),
+            ScheduleHeaderDayLabel("周三", "12月31日"),
+            ScheduleHeaderDayLabel("周四", "1月1日"),
+            ScheduleHeaderDayLabel("周五", "1月2日"),
+            ScheduleHeaderDayLabel("周六", "1月3日"),
+            ScheduleHeaderDayLabel("周日", "1月4日"),
+        ),
+        week(startDate = "2025-12-29").headerDayLabels(),
+    )
   }
 
   @Test
-  fun formatWeekDateRangeReturnsNullWhenDateIsMissing() {
-    assertNull(formatWeekDateRange("2026-04-14", null))
+  fun headerDayLabelsFallsBackToWeekdaysWhenDateParsingFails() {
+    assertEquals(defaultScheduleHeaderDayLabels(), week(startDate = "2026/04/13").headerDayLabels())
   }
 }
+
+private fun week(startDate: String) =
+    Week(
+        startDate = startDate,
+        endDate = "2026-04-19",
+        term = "2025-2026-2",
+        curWeek = false,
+        serialNumber = 7,
+        name = "第7周",
+    )


### PR DESCRIPTION
## Summary
- show the selected week's date range under the schedule title in the top bar
- add a reusable formatter for week date ranges with a safe raw-string fallback
- cover the formatter with common tests

Refs #52

## Testing
- `./gradlew spotlessApply composeApp:jvmTest --tests cn.edu.ubaa.ui.screens.schedule.ScheduleDateLabelsTest`
