### PR TITLE
fix(signin): 修复签到失败错误码 106

### DIFF
--- a/server/src/main/kotlin/cn/edu/ubaa/signin/SigninClient.kt
+++ b/server/src/main/kotlin/cn/edu/ubaa/signin/SigninClient.kt
@@ -39,6 +39,7 @@ class SigninClient(
 
   private var userId: String? = null
   private var sessionId: String? = null
+  private var lastLoginError: String? = null
   private val loginMutex = Mutex()
 
   private suspend fun ensureSession(): SessionManager.UserSession {
@@ -75,6 +76,9 @@ class SigninClient(
           val body = response.bodyAsText()
           val jsonResponse = json.parseToJsonElement(body).jsonObject
           if (jsonResponse["STATUS"]?.jsonPrimitive?.intOrNull != 0) {
+            lastLoginError =
+                jsonResponse["ERRMSG"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+                    ?: "登录失败"
             markUnauthenticated()
             return@observeUpstreamRequest false
           }
@@ -158,7 +162,11 @@ class SigninClient(
 
   /** 提交签到请求。 */
   suspend fun signIn(courseId: String): Pair<Boolean, String> {
-    if (userId == null || sessionId == null) if (!login()) return false to "登录失败"
+    if (userId == null || sessionId == null) if (!login()) {
+      val error = lastLoginError ?: "iclass 登录失败"
+      lastLoginError = null
+      return false to error
+    }
     return try {
       val serverTimestamp =
           AppObservability.observeUpstreamRequest("iclass", "get_timestamp") {
@@ -176,12 +184,16 @@ class SigninClient(
 
       AppObservability.observeUpstreamRequest("iclass", "sign_in") {
         val response =
-            client.post(
-                VpnCipher.toVpnUrl("http://iclass.buaa.edu.cn:8081/app/course/stu_scan_sign.action")
+            client.submitForm(
+                url =
+                    VpnCipher.toVpnUrl(
+                        "http://iclass.buaa.edu.cn:8081/app/course/stu_scan_sign.action"
+                    ),
+                formParameters = Parameters.build { append("id", userId!!) },
             ) {
+              header("sessionId", sessionId)
               parameter("courseSchedId", courseId)
               parameter("timestamp", serverTimestamp)
-              setBody(FormDataContent(Parameters.build { append("id", userId!!) }))
             }
         val jsonResponse = json.parseToJsonElement(response.bodyAsText()).jsonObject
         val success =
@@ -210,6 +222,7 @@ class SigninClient(
       "不是上课时间" in message -> "当前不是上课时间，无法签到"
       "已结束" in message -> "本次签到已结束"
       "范围" in message -> "当前不在可签到范围内"
+      "用户不存在" in message -> "签到账号不存在，请联系管理员"
       "课程" in message && "不存在" in message -> "未找到对应课程，请刷新后重试"
       else -> "签到失败，请稍后重试"
     }
@@ -219,6 +232,7 @@ class SigninClient(
     client.close()
     userId = null
     sessionId = null
+    lastLoginError = null
   }
 }
 

--- a/server/src/main/kotlin/cn/edu/ubaa/signin/SigninClient.kt
+++ b/server/src/main/kotlin/cn/edu/ubaa/signin/SigninClient.kt
@@ -77,8 +77,7 @@ class SigninClient(
           val jsonResponse = json.parseToJsonElement(body).jsonObject
           if (jsonResponse["STATUS"]?.jsonPrimitive?.intOrNull != 0) {
             lastLoginError =
-                jsonResponse["ERRMSG"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-                    ?: "登录失败"
+                jsonResponse["ERRMSG"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: "登录失败"
             markUnauthenticated()
             return@observeUpstreamRequest false
           }
@@ -162,11 +161,12 @@ class SigninClient(
 
   /** 提交签到请求。 */
   suspend fun signIn(courseId: String): Pair<Boolean, String> {
-    if (userId == null || sessionId == null) if (!login()) {
-      val error = lastLoginError ?: "iclass 登录失败"
-      lastLoginError = null
-      return false to error
-    }
+    if (userId == null || sessionId == null)
+        if (!login()) {
+          val error = lastLoginError ?: "iclass 登录失败"
+          lastLoginError = null
+          return false to error
+        }
     return try {
       val serverTimestamp =
           AppObservability.observeUpstreamRequest("iclass", "get_timestamp") {

--- a/shared/src/commonMain/kotlin/cn/edu/ubaa/api/local/LocalSigninApi.kt
+++ b/shared/src/commonMain/kotlin/cn/edu/ubaa/api/local/LocalSigninApi.kt
@@ -9,6 +9,7 @@ import cn.edu.ubaa.model.dto.SigninActionResponse
 import cn.edu.ubaa.model.dto.SigninClassDto
 import cn.edu.ubaa.model.dto.SigninStatusResponse
 import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -34,6 +35,7 @@ internal class LocalSigninApiBackend : SigninApiBackend {
   private val json = Json { ignoreUnknownKeys = true }
   private val sessionMutex = Mutex()
   private val sessionCache = mutableMapOf<String, LocalSigninSession>()
+  private var loginLastError: String? = null
 
   internal fun clearCache() {
     sessionCache.clear()
@@ -74,7 +76,9 @@ internal class LocalSigninApiBackend : SigninApiBackend {
         LocalAuthSessionStore.get() ?: return Result.failure(localUnauthenticatedApiException())
     val signinSession = runCatching { currentSession(authSession.studentId()) }.getOrNull()
     if (signinSession == null) {
-      return Result.success(SigninActionResponse(code = 400, success = false, message = "登录失败"))
+      val error = loginLastError ?: "iclass 登录失败"
+      loginLastError = null
+      return Result.success(SigninActionResponse(code = 400, success = false, message = error))
     }
 
     return try {
@@ -95,12 +99,16 @@ internal class LocalSigninApiBackend : SigninApiBackend {
       }
 
       val response =
-          LocalUpstreamClientProvider.shared().post(
-              localUpstreamUrl("http://iclass.buaa.edu.cn:8081/app/course/stu_scan_sign.action")
+          LocalUpstreamClientProvider.shared().submitForm(
+              url =
+                  localUpstreamUrl(
+                      "http://iclass.buaa.edu.cn:8081/app/course/stu_scan_sign.action"
+                  ),
+              formParameters = Parameters.build { append("id", signinSession.userId) },
           ) {
+            header("sessionId", signinSession.sessionId)
             parameter("courseSchedId", courseId)
             parameter("timestamp", timestamp)
-            setBody(FormDataContent(Parameters.build { append("id", signinSession.userId) }))
           }
       val payload = json.parseToJsonElement(response.bodyAsText()).jsonObject
       val success =
@@ -147,6 +155,9 @@ internal class LocalSigninApiBackend : SigninApiBackend {
 
     val payload = json.parseToJsonElement(response.bodyAsText()).jsonObject
     if (payload["STATUS"]?.jsonPrimitive?.intOrNull != 0) {
+      loginLastError =
+          payload["ERRMSG"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+              ?: "登录失败"
       return null
     }
 
@@ -223,6 +234,7 @@ internal fun sanitizeLocalSigninMessage(success: Boolean, rawMessage: String?): 
     "不是上课时间" in message -> "当前不是上课时间，无法签到"
     "已结束" in message -> "本次签到已结束"
     "范围" in message -> "当前不在可签到范围内"
+    "用户不存在" in message -> "签到账号不存在，请联系管理员"
     "课程" in message && "不存在" in message -> "未找到对应课程，请刷新后重试"
     else -> "签到失败，请稍后重试"
   }

--- a/shared/src/commonMain/kotlin/cn/edu/ubaa/api/local/LocalSigninApi.kt
+++ b/shared/src/commonMain/kotlin/cn/edu/ubaa/api/local/LocalSigninApi.kt
@@ -8,13 +8,10 @@ import cn.edu.ubaa.api.resolveSigninRedirectUrl
 import cn.edu.ubaa.model.dto.SigninActionResponse
 import cn.edu.ubaa.model.dto.SigninClassDto
 import cn.edu.ubaa.model.dto.SigninStatusResponse
-import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -156,8 +153,7 @@ internal class LocalSigninApiBackend : SigninApiBackend {
     val payload = json.parseToJsonElement(response.bodyAsText()).jsonObject
     if (payload["STATUS"]?.jsonPrimitive?.intOrNull != 0) {
       loginLastError =
-          payload["ERRMSG"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-              ?: "登录失败"
+          payload["ERRMSG"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: "登录失败"
       return null
     }
 


### PR DESCRIPTION
## 问题

签到接口返回错误码 106（用户不存在），上游 iclass API 的签到 POST 请求缺少 `sessionId` header，且使用了错误的 Content-Type。

## 根因

对比 UBAANext (C++) 可用实现，发现两个差异：
1. **缺少 `sessionId` header** — `getClasses()` 有带但 `signIn()` 遗漏
2. **错误 Content-Type** — `FormDataContent` (multipart) 应为 `submitForm` (form-urlencoded)

## 修复

- `server/.../SigninClient.kt`: 签到 POST 加入 `header("sessionId", sessionId)`，改用 `submitForm`
- `shared/.../LocalSigninApi.kt`: 同上
- 捕获 iclass 登录失败的 ERRMSG 不再丢弃
- `sanitizeSignInMessage` 新增 "用户不存在" 映射