### PR TITLE
feat: add grade score update reminders

### DIFF
--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/navigation/HomeBootstrapCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/navigation/HomeBootstrapCoordinator.kt
@@ -19,6 +19,7 @@ internal data class HomeBootstrapActions(
     val loadBykc: suspend (Boolean) -> Unit,
     val loadCgyy: suspend (Boolean) -> Unit,
     val loadYgdk: suspend (Boolean) -> Unit,
+    val checkGradeScores: suspend (Boolean) -> Unit,
 )
 
 internal class HomeBootstrapCoordinator(private val scope: CoroutineScope) {
@@ -47,6 +48,7 @@ internal class HomeBootstrapCoordinator(private val scope: CoroutineScope) {
                       launch { actions.loadBykc(forceRefresh) },
                       launch { actions.loadCgyy(forceRefresh) },
                       launch { actions.loadYgdk(forceRefresh) },
+                      launch { actions.checkGradeScores(forceRefresh) },
                   )
                   .joinAll()
             }

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/navigation/MainAppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/navigation/MainAppScreen.kt
@@ -43,8 +43,8 @@ import cn.edu.ubaa.ui.screens.evaluation.EvaluationViewModel
 import cn.edu.ubaa.ui.screens.exam.ExamScreen
 import cn.edu.ubaa.ui.screens.exam.ExamUiState
 import cn.edu.ubaa.ui.screens.exam.ExamViewModel
-import cn.edu.ubaa.ui.screens.grade.GradeScreen
 import cn.edu.ubaa.ui.screens.grade.GradeScoreWatchViewModel
+import cn.edu.ubaa.ui.screens.grade.GradeScreen
 import cn.edu.ubaa.ui.screens.grade.GradeUiState
 import cn.edu.ubaa.ui.screens.grade.GradeViewModel
 import cn.edu.ubaa.ui.screens.judge.JudgeAssignmentDetailScreen

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/navigation/MainAppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/navigation/MainAppScreen.kt
@@ -44,6 +44,7 @@ import cn.edu.ubaa.ui.screens.exam.ExamScreen
 import cn.edu.ubaa.ui.screens.exam.ExamUiState
 import cn.edu.ubaa.ui.screens.exam.ExamViewModel
 import cn.edu.ubaa.ui.screens.grade.GradeScreen
+import cn.edu.ubaa.ui.screens.grade.GradeScoreWatchViewModel
 import cn.edu.ubaa.ui.screens.grade.GradeUiState
 import cn.edu.ubaa.ui.screens.grade.GradeViewModel
 import cn.edu.ubaa.ui.screens.judge.JudgeAssignmentDetailScreen
@@ -188,6 +189,11 @@ fun MainAppScreen(
         null
       }
   val gradeUiState = gradeViewModel?.uiState?.collectAsState()?.value ?: GradeUiState()
+  val gradeScoreWatchViewModel: GradeScoreWatchViewModel =
+      viewModel(key = "grade-score-watch-${userData.schoolid}") {
+        GradeScoreWatchViewModel(userKey = userData.schoolid)
+      }
+  val gradeScoreWatchUiState by gradeScoreWatchViewModel.uiState.collectAsState()
 
   val signinViewModel: SigninViewModel =
       viewModel(key = "signin-${userData.schoolid}") { SigninViewModel() }
@@ -303,7 +309,8 @@ fun MainAppScreen(
     if (shouldLoadYgdkHomeOverview && ygdkUiState.isLoading) add(HomeTodoSource.YGDK)
   }
   val homeTodoLoading = homeTodoLoadingSources.isNotEmpty()
-  val homeContentLoading = todayScheduleState.isLoading || homeTodoLoading
+  val homeContentLoading =
+      todayScheduleState.isLoading || homeTodoLoading || gradeScoreWatchUiState.isLoading
   val homeIsRefreshing =
       homeManualRefreshPending &&
           (homeManualRefreshStarted || homeBootstrapRunning || homeContentLoading)
@@ -326,7 +333,8 @@ fun MainAppScreen(
             !bykcViewModel.hasChosenCoursesLoaded() ||
             cgyyViewModel?.hasOrdersLoaded() != true ||
             !scheduleViewModel.hasCurrentWeekLoaded() ||
-            (shouldLoadYgdkHomeOverview && ygdkViewModel.hasOverviewLoaded() != true)
+            (shouldLoadYgdkHomeOverview && ygdkViewModel.hasOverviewLoaded() != true) ||
+            !gradeScoreWatchViewModel.hasChecked()
     homeBootstrapCoordinator.restart(
         HomeBootstrapActions(
             loadTodaySchedule = { force ->
@@ -342,6 +350,9 @@ fun MainAppScreen(
               if (shouldLoadYgdkHomeOverview) {
                 ygdkViewModel.ensureOverviewLoaded(forceRefresh = force)
               }
+            },
+            checkGradeScores = { force ->
+              gradeScoreWatchViewModel.checkForUpdates(forceRefresh = force)
             },
         ),
         forceRefresh = forceRefresh,
@@ -494,6 +505,11 @@ fun MainAppScreen(
     }
   }
 
+  fun openScoresFromHomeNotice() {
+    gradeScoreWatchViewModel.consumeNotice()
+    navigateTo(AppScreen.GRADE)
+  }
+
   LaunchedEffect(
       ygdkUiState.overview,
       ygdkWeekReminderKey,
@@ -550,6 +566,7 @@ fun MainAppScreen(
     ygdkViewModel?.resetLoadedState()
     examViewModel?.resetLoadedState()
     gradeViewModel?.resetLoadedState()
+    gradeScoreWatchViewModel.resetLoadedState()
     evaluationViewModel?.resetLoadedState()
     libBookViewModel?.resetLoadedState()
     // 刷新当前页面数据
@@ -783,8 +800,11 @@ fun MainAppScreen(
                   todoFailedSources = homeTodoFailedSources,
                   signingTodoId =
                       signinUiState.signingInCourseId?.let { courseId -> "signin:$courseId" },
+                  scoreUpdateNotice = gradeScoreWatchUiState.notice,
                   onRetrySchedule = { scheduleViewModel.loadTodaySchedule() },
                   onRefresh = { refreshHomeData() },
+                  onOpenScoresClick = { openScoresFromHomeNotice() },
+                  onDismissScoreNotice = { gradeScoreWatchViewModel.consumeNotice() },
                   onTodoClick = { todoItem -> handleHomeTodoClick(todoItem) },
                   onSigninTodoClick = { courseId -> signinViewModel.performSignin(courseId) },
               )

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/grade/GradeScoreWatchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/grade/GradeScoreWatchViewModel.kt
@@ -61,16 +61,14 @@ internal constructor(
       _uiState.value = _uiState.value.copy(isLoading = true, error = null)
 
       val terms =
-          termsSource
-              .getTerms(forceRefresh)
-              .getOrElse { exception ->
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = false,
-                        error = exception.message ?: "检查成绩更新失败",
-                    )
-                return@launch
-              }
+          termsSource.getTerms(forceRefresh).getOrElse { exception ->
+            _uiState.value =
+                _uiState.value.copy(
+                    isLoading = false,
+                    error = exception.message ?: "检查成绩更新失败",
+                )
+            return@launch
+          }
 
       val currentTerm = terms.currentTermOrNull()
       if (currentTerm == null) {
@@ -79,16 +77,14 @@ internal constructor(
       }
 
       val gradeData =
-          gradeSource
-              .getGrades(currentTerm.itemCode)
-              .getOrElse { exception ->
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = false,
-                        error = exception.message ?: "检查成绩更新失败",
-                    )
-                return@launch
-              }
+          gradeSource.getGrades(currentTerm.itemCode).getOrElse { exception ->
+            _uiState.value =
+                _uiState.value.copy(
+                    isLoading = false,
+                    error = exception.message ?: "检查成绩更新失败",
+                )
+            return@launch
+          }
 
       val latestCache = gradeData.toScoreCache(currentTerm)
       if (latestCache.scores.isEmpty()) {

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/grade/GradeScoreWatchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/grade/GradeScoreWatchViewModel.kt
@@ -1,0 +1,187 @@
+package cn.edu.ubaa.ui.screens.grade
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cn.edu.ubaa.api.storage.GradeScoreCacheStore
+import cn.edu.ubaa.api.storage.StoredGradeScoreCache
+import cn.edu.ubaa.api.storage.StoredGradeScoreEntry
+import cn.edu.ubaa.model.dto.Grade
+import cn.edu.ubaa.model.dto.GradeData
+import cn.edu.ubaa.model.dto.Term
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+internal interface GradeScoreCache {
+  fun get(userKey: String): StoredGradeScoreCache?
+
+  fun save(userKey: String, cache: StoredGradeScoreCache)
+}
+
+internal object PersistentGradeScoreCache : GradeScoreCache {
+  override fun get(userKey: String): StoredGradeScoreCache? = GradeScoreCacheStore.get(userKey)
+
+  override fun save(userKey: String, cache: StoredGradeScoreCache) {
+    GradeScoreCacheStore.save(userKey, cache)
+  }
+}
+
+class GradeScoreWatchViewModel
+internal constructor(
+    private val userKey: String,
+    private val gradeSource: GradeDataSource = ApiGradeDataSource(),
+    private val termsSource: GradeTermsSource = RepositoryGradeTermsSource(),
+    private val cache: GradeScoreCache = PersistentGradeScoreCache,
+) : ViewModel() {
+  private var loadedOnce = false
+
+  private val _uiState = MutableStateFlow(GradeScoreWatchUiState())
+  val uiState: StateFlow<GradeScoreWatchUiState> = _uiState.asStateFlow()
+
+  fun hasChecked(): Boolean = loadedOnce
+
+  fun ensureChecked(forceRefresh: Boolean = false) {
+    if (!forceRefresh && loadedOnce) return
+    checkForUpdates(forceRefresh)
+  }
+
+  fun resetLoadedState() {
+    loadedOnce = false
+    _uiState.value = GradeScoreWatchUiState()
+  }
+
+  fun consumeNotice() {
+    _uiState.value = _uiState.value.copy(notice = null)
+  }
+
+  fun checkForUpdates(forceRefresh: Boolean = false) {
+    loadedOnce = true
+    viewModelScope.launch {
+      _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+
+      val terms =
+          termsSource
+              .getTerms(forceRefresh)
+              .getOrElse { exception ->
+                _uiState.value =
+                    _uiState.value.copy(
+                        isLoading = false,
+                        error = exception.message ?: "检查成绩更新失败",
+                    )
+                return@launch
+              }
+
+      val currentTerm = terms.currentTermOrNull()
+      if (currentTerm == null) {
+        _uiState.value = _uiState.value.copy(isLoading = false, error = null)
+        return@launch
+      }
+
+      val gradeData =
+          gradeSource
+              .getGrades(currentTerm.itemCode)
+              .getOrElse { exception ->
+                _uiState.value =
+                    _uiState.value.copy(
+                        isLoading = false,
+                        error = exception.message ?: "检查成绩更新失败",
+                    )
+                return@launch
+              }
+
+      val latestCache = gradeData.toScoreCache(currentTerm)
+      if (latestCache.scores.isEmpty()) {
+        _uiState.value = _uiState.value.copy(isLoading = false, error = null)
+        return@launch
+      }
+
+      val previousCache = cache.get(userKey)
+      cache.save(userKey, latestCache)
+
+      val changedScores = previousCache?.changedScoresComparedWith(latestCache).orEmpty()
+      _uiState.value =
+          _uiState.value.copy(
+              isLoading = false,
+              error = null,
+              notice =
+                  if (changedScores.isNotEmpty()) {
+                    GradeScoreUpdateNotice(
+                        termCode = latestCache.termCode,
+                        termName = latestCache.termName ?: currentTerm.itemName,
+                        changedScores = changedScores,
+                    )
+                  } else {
+                    _uiState.value.notice
+                  },
+          )
+    }
+  }
+}
+
+data class GradeScoreWatchUiState(
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val notice: GradeScoreUpdateNotice? = null,
+)
+
+data class GradeScoreUpdateNotice(
+    val termCode: String,
+    val termName: String,
+    val changedScores: List<ChangedGradeScore>,
+) {
+  val changedCount: Int
+    get() = changedScores.size
+}
+
+data class ChangedGradeScore(
+    val courseName: String,
+    val oldScore: String?,
+    val newScore: String?,
+)
+
+private fun List<Term>.currentTermOrNull(): Term? = find { it.selected } ?: firstOrNull()
+
+private fun GradeData.toScoreCache(term: Term): StoredGradeScoreCache =
+    StoredGradeScoreCache(
+        termCode = term.itemCode,
+        termName = term.itemName,
+        scores = grades.mapNotNull { it.toScoreEntry() }.sortedBy { it.key },
+    )
+
+private fun Grade.toScoreEntry(): StoredGradeScoreEntry? {
+  val key = scoreIdentityKey() ?: return null
+  return StoredGradeScoreEntry(
+      key = key,
+      courseName = courseName?.trim()?.takeIf { it.isNotEmpty() },
+      courseCode = courseCode?.trim()?.takeIf { it.isNotEmpty() },
+      score = score?.trim()?.takeIf { it.isNotEmpty() },
+  )
+}
+
+private fun Grade.scoreIdentityKey(): String? =
+    id?.trim()?.takeIf { it.isNotEmpty() }?.let { "id:$it" }
+        ?: courseCode?.trim()?.takeIf { it.isNotEmpty() }?.let { "code:$it" }
+        ?: courseName?.trim()?.takeIf { it.isNotEmpty() }?.let { "name:$it" }
+
+private fun StoredGradeScoreCache.changedScoresComparedWith(
+    latest: StoredGradeScoreCache
+): List<ChangedGradeScore> {
+  if (termCode != latest.termCode) return emptyList()
+  val previousByKey = scores.associateBy { it.key }
+  return latest.scores.mapNotNull { latestEntry ->
+    val previousEntry = previousByKey[latestEntry.key]
+    if (previousEntry?.score == latestEntry.score) return@mapNotNull null
+    if (previousEntry == null && latestEntry.score == null) return@mapNotNull null
+    ChangedGradeScore(
+        courseName =
+            latestEntry.courseName
+                ?: previousEntry?.courseName
+                ?: latestEntry.courseCode
+                ?: previousEntry?.courseCode
+                ?: "未命名课程",
+        oldScore = previousEntry?.score,
+        newScore = latestEntry.score,
+    )
+  }
+}

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/grade/GradeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/grade/GradeViewModel.kt
@@ -22,11 +22,11 @@ internal interface GradeTermsSource {
   suspend fun getTerms(forceRefresh: Boolean): Result<List<Term>>
 }
 
-private class ApiGradeDataSource(private val gradeApi: GradeApi = GradeApi()) : GradeDataSource {
+internal class ApiGradeDataSource(private val gradeApi: GradeApi = GradeApi()) : GradeDataSource {
   override suspend fun getGrades(termCode: String): Result<GradeData> = gradeApi.getGrades(termCode)
 }
 
-private class RepositoryGradeTermsSource(
+internal class RepositoryGradeTermsSource(
     private val termRepository: TermRepository = GlobalTermRepository.instance
 ) : GradeTermsSource {
   override suspend fun getTerms(forceRefresh: Boolean): Result<List<Term>> =

--- a/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/menu/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/cn/edu/ubaa/ui/screens/menu/HomeScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cn.edu.ubaa.model.dto.TodayClass
+import cn.edu.ubaa.ui.screens.grade.GradeScoreUpdateNotice
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlinx.datetime.TimeZone
@@ -61,8 +62,11 @@ internal fun HomeScreen(
     todoLoadingSources: List<HomeTodoSource>,
     todoFailedSources: List<HomeTodoSource>,
     signingTodoId: String?,
+    scoreUpdateNotice: GradeScoreUpdateNotice?,
     onRetrySchedule: () -> Unit,
     onRefresh: () -> Unit,
+    onOpenScoresClick: () -> Unit,
+    onDismissScoreNotice: () -> Unit,
     onTodoClick: (HomeTodoItem) -> Unit,
     onSigninTodoClick: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -100,6 +104,16 @@ internal fun HomeScreen(
               text = "${today.month.ordinal + 1}月${today.day}日",
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+
+      if (scoreUpdateNotice != null) {
+        item {
+          HomeScoreUpdateBanner(
+              notice = scoreUpdateNotice,
+              onOpenScoresClick = onOpenScoresClick,
+              onDismiss = onDismissScoreNotice,
           )
         }
       }
@@ -464,6 +478,47 @@ private fun HomeInfoBanner(message: String) {
         style = MaterialTheme.typography.bodySmall,
         modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
     )
+  }
+}
+
+@Composable
+private fun HomeScoreUpdateBanner(
+    notice: GradeScoreUpdateNotice,
+    onOpenScoresClick: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+  val title =
+      if (notice.changedCount == 1) {
+        "${notice.changedScores.first().courseName} 成绩已更新"
+      } else {
+        "${notice.termName} 有 ${notice.changedCount} 门成绩更新"
+      }
+  Surface(
+      modifier = Modifier.fillMaxWidth(),
+      color = MaterialTheme.colorScheme.primaryContainer,
+      contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+      shape = MaterialTheme.shapes.medium,
+  ) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(14.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "前往成绩查询查看最新分数",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+      }
+      TextButton(onClick = onOpenScoresClick) { Text("查看") }
+      TextButton(onClick = onDismiss) { Text("忽略") }
+    }
   }
 }
 

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/GradeScoreWatchViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/GradeScoreWatchViewModelTest.kt
@@ -1,0 +1,233 @@
+package cn.edu.ubaa.ui
+
+import cn.edu.ubaa.api.storage.StoredGradeScoreCache
+import cn.edu.ubaa.api.storage.StoredGradeScoreEntry
+import cn.edu.ubaa.model.dto.Grade
+import cn.edu.ubaa.model.dto.GradeData
+import cn.edu.ubaa.model.dto.Term
+import cn.edu.ubaa.ui.screens.grade.GradeDataSource
+import cn.edu.ubaa.ui.screens.grade.GradeScoreCache
+import cn.edu.ubaa.ui.screens.grade.GradeScoreWatchViewModel
+import cn.edu.ubaa.ui.screens.grade.GradeTermsSource
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GradeScoreWatchViewModelTest {
+  @AfterTest
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun `first non-empty current term seeds cache without notice`() = runTest {
+    setMainDispatcher(testScheduler)
+    val cache = FakeGradeScoreCache()
+    val viewModel =
+        GradeScoreWatchViewModel(
+            userKey = "test-user",
+            termsSource = FakeScoreWatchTermsSource(listOf(sampleTerm())),
+            gradeSource = FakeScoreWatchDataSource("2025-2026-1" to grades("高等数学", "90")),
+            cache = cache,
+        )
+
+    viewModel.ensureChecked()
+    advanceUntilIdle()
+
+    assertNull(viewModel.uiState.value.notice)
+    assertEquals("90", cache.get("test-user")?.scores?.singleOrNull()?.score)
+    assertTrue(viewModel.hasChecked())
+  }
+
+  @Test
+  fun `same scores update cache without notice`() = runTest {
+    setMainDispatcher(testScheduler)
+    val cache =
+        FakeGradeScoreCache(
+            mapOf("test-user" to cached("2025-2026-1", score = "90", courseName = "高等数学"))
+        )
+    val viewModel =
+        GradeScoreWatchViewModel(
+            userKey = "test-user",
+            termsSource = FakeScoreWatchTermsSource(listOf(sampleTerm())),
+            gradeSource = FakeScoreWatchDataSource("2025-2026-1" to grades("高等数学", "90")),
+            cache = cache,
+        )
+
+    viewModel.ensureChecked()
+    advanceUntilIdle()
+
+    assertNull(viewModel.uiState.value.notice)
+    assertEquals("90", cache.get("test-user")?.scores?.singleOrNull()?.score)
+  }
+
+  @Test
+  fun `changed score updates cache and emits notice`() = runTest {
+    setMainDispatcher(testScheduler)
+    val cache =
+        FakeGradeScoreCache(
+            mapOf("test-user" to cached("2025-2026-1", score = "90", courseName = "高等数学"))
+        )
+    val viewModel =
+        GradeScoreWatchViewModel(
+            userKey = "test-user",
+            termsSource = FakeScoreWatchTermsSource(listOf(sampleTerm())),
+            gradeSource = FakeScoreWatchDataSource("2025-2026-1" to grades("高等数学", "95")),
+            cache = cache,
+        )
+
+    viewModel.ensureChecked()
+    advanceUntilIdle()
+
+    val notice = viewModel.uiState.value.notice
+    assertEquals("2025-2026学年第一学期", notice?.termName)
+    assertEquals(1, notice?.changedCount)
+    assertEquals("高等数学", notice?.changedScores?.singleOrNull()?.courseName)
+    assertEquals("90", notice?.changedScores?.singleOrNull()?.oldScore)
+    assertEquals("95", notice?.changedScores?.singleOrNull()?.newScore)
+    assertEquals("95", cache.get("test-user")?.scores?.singleOrNull()?.score)
+  }
+
+  @Test
+  fun `empty current term is ignored and does not overwrite cache`() = runTest {
+    setMainDispatcher(testScheduler)
+    val cache =
+        FakeGradeScoreCache(
+            mapOf("test-user" to cached("2025-2026-1", score = "90", courseName = "高等数学"))
+        )
+    val viewModel =
+        GradeScoreWatchViewModel(
+            userKey = "test-user",
+            termsSource = FakeScoreWatchTermsSource(listOf(sampleTerm())),
+            gradeSource = FakeScoreWatchDataSource("2025-2026-1" to GradeData("2025-2026-1")),
+            cache = cache,
+        )
+
+    viewModel.ensureChecked()
+    advanceUntilIdle()
+
+    assertNull(viewModel.uiState.value.notice)
+    assertEquals("90", cache.get("test-user")?.scores?.singleOrNull()?.score)
+  }
+
+  @Test
+  fun `only selected current term is watched`() = runTest {
+    setMainDispatcher(testScheduler)
+    val cache = FakeGradeScoreCache()
+    val terms =
+        listOf(
+            sampleTerm("2025-2026-1", selected = true),
+            sampleTerm("2024-2025-2", selected = false),
+        )
+    val gradeSource =
+        FakeScoreWatchDataSource(
+            "2025-2026-1" to grades("高等数学", "90"),
+            "2024-2025-2" to grades("大学物理", "95"),
+        )
+    val viewModel =
+        GradeScoreWatchViewModel(
+            userKey = "test-user",
+            termsSource = FakeScoreWatchTermsSource(terms),
+            gradeSource = gradeSource,
+            cache = cache,
+        )
+
+    viewModel.ensureChecked()
+    advanceUntilIdle()
+
+    assertEquals(listOf("2025-2026-1"), gradeSource.requestedTerms)
+    assertEquals("2025-2026-1", cache.get("test-user")?.termCode)
+  }
+
+  private fun setMainDispatcher(testScheduler: TestCoroutineScheduler) {
+    Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+  }
+}
+
+private class FakeGradeScoreCache(initial: Map<String, StoredGradeScoreCache> = emptyMap()) :
+    GradeScoreCache {
+  private val data = initial.toMutableMap()
+
+  override fun get(userKey: String): StoredGradeScoreCache? = data[userKey]
+
+  override fun save(userKey: String, cache: StoredGradeScoreCache) {
+    data[userKey] = cache
+  }
+}
+
+private class FakeScoreWatchTermsSource(private val terms: List<Term>) : GradeTermsSource {
+  override suspend fun getTerms(forceRefresh: Boolean): Result<List<Term>> = Result.success(terms)
+}
+
+private class FakeScoreWatchDataSource(private vararg val data: Pair<String, GradeData>) :
+    GradeDataSource {
+  val requestedTerms = mutableListOf<String>()
+  private val dataByTerm = data.toMap()
+
+  override suspend fun getGrades(termCode: String): Result<GradeData> {
+    requestedTerms += termCode
+    return Result.success(dataByTerm.getValue(termCode))
+  }
+}
+
+private fun grades(courseName: String, score: String): GradeData =
+    GradeData(
+        termCode = "2025-2026-1",
+        grades =
+            listOf(
+                Grade(
+                    id = "grade-$courseName",
+                    termCode = "2025-2026-1",
+                    courseName = courseName,
+                    courseCode = courseName,
+                    score = score,
+                )
+            ),
+    )
+
+private fun cached(
+    termCode: String,
+    score: String,
+    courseName: String,
+): StoredGradeScoreCache =
+    StoredGradeScoreCache(
+        termCode = termCode,
+        termName = "2025-2026学年第一学期",
+        scores =
+            listOf(
+                StoredGradeScoreEntry(
+                    key = "id:grade-$courseName",
+                    courseName = courseName,
+                    courseCode = courseName,
+                    score = score,
+                )
+            ),
+    )
+
+private fun sampleTerm(
+    itemCode: String = "2025-2026-1",
+    selected: Boolean = true,
+): Term =
+    Term(
+        itemCode = itemCode,
+        itemName =
+            if (itemCode == "2025-2026-1") {
+              "2025-2026学年第一学期"
+            } else {
+              itemCode
+            },
+        selected = selected,
+        itemIndex = 0,
+    )

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/GradeScoreWatchViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/GradeScoreWatchViewModelTest.kt
@@ -12,7 +12,6 @@ import cn.edu.ubaa.ui.screens.grade.GradeTermsSource
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers

--- a/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/navigation/HomeBootstrapCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/cn/edu/ubaa/ui/navigation/HomeBootstrapCoordinatorTest.kt
@@ -34,6 +34,7 @@ class HomeBootstrapCoordinatorTest {
             "bykc:start:false@0",
             "cgyy:start:false@0",
             "ygdk:start:false@0",
+            "grade:start:false@0",
         ),
         events,
     )
@@ -51,6 +52,7 @@ class HomeBootstrapCoordinatorTest {
             "bykc:start:false@0",
             "cgyy:start:false@0",
             "ygdk:start:false@0",
+            "grade:start:false@0",
             "schedule:end:false@100",
             "signin:end:false@100",
             "spoc:end:false@100",
@@ -58,6 +60,7 @@ class HomeBootstrapCoordinatorTest {
             "bykc:end:false@100",
             "cgyy:end:false@100",
             "ygdk:end:false@100",
+            "grade:end:false@100",
         ),
         events,
     )
@@ -82,6 +85,7 @@ class HomeBootstrapCoordinatorTest {
             "bykc:true@0",
             "cgyy:true@0",
             "ygdk:true@0",
+            "grade:true@0",
         ),
         events,
     )
@@ -118,6 +122,7 @@ class HomeBootstrapCoordinatorTest {
             loadBykc = {},
             loadCgyy = {},
             loadYgdk = {},
+            checkGradeScores = {},
         )
 
     coordinator.restart(actions)
@@ -140,6 +145,7 @@ class HomeBootstrapCoordinatorTest {
         loadBykc = { force -> events += "bykc:$force@${currentTime()}" },
         loadCgyy = { force -> events += "cgyy:$force@${currentTime()}" },
         loadYgdk = { force -> events += "ygdk:$force@${currentTime()}" },
+        checkGradeScores = { force -> events += "grade:$force@${currentTime()}" },
     )
   }
 
@@ -161,6 +167,7 @@ class HomeBootstrapCoordinatorTest {
         loadBykc = { force -> record("bykc", force) },
         loadCgyy = { force -> record("cgyy", force) },
         loadYgdk = { force -> record("ygdk", force) },
+        checkGradeScores = { force -> record("grade", force) },
     )
   }
 }

--- a/shared/src/commonMain/kotlin/cn/edu/ubaa/api/ConnectionRuntime.kt
+++ b/shared/src/commonMain/kotlin/cn/edu/ubaa/api/ConnectionRuntime.kt
@@ -10,6 +10,7 @@ import cn.edu.ubaa.api.local.LocalUpstreamClientProvider
 import cn.edu.ubaa.api.storage.AuthTokensStore
 import cn.edu.ubaa.api.storage.ClientIdStore
 import cn.edu.ubaa.api.storage.CredentialStore
+import cn.edu.ubaa.api.storage.GradeScoreCacheStore
 import cn.edu.ubaa.repository.GlobalTermRepository
 import cn.edu.ubaa.supportsLocalConnectionModes
 import com.russhwolf.settings.Settings
@@ -111,6 +112,7 @@ object ConnectionRuntime {
   fun resetSession() {
     AuthTokensStore.clearAllScopes()
     ClientIdStore.clearAllScopes()
+    GradeScoreCacheStore.clearAllScopes()
     LocalAuthSessionStore.clearAllScopes()
     LocalCookieStore.clearAllScopes()
     CredentialStore.setAutoLogin(false)

--- a/shared/src/commonMain/kotlin/cn/edu/ubaa/api/storage/GradeScoreCacheStore.kt
+++ b/shared/src/commonMain/kotlin/cn/edu/ubaa/api/storage/GradeScoreCacheStore.kt
@@ -1,0 +1,79 @@
+package cn.edu.ubaa.api.storage
+
+import cn.edu.ubaa.api.ConnectionMode
+import cn.edu.ubaa.api.ConnectionModeStore
+import com.russhwolf.settings.Settings
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class StoredGradeScoreCache(
+    val termCode: String,
+    val termName: String? = null,
+    val scores: List<StoredGradeScoreEntry> = emptyList(),
+)
+
+@Serializable
+data class StoredGradeScoreEntry(
+    val key: String,
+    val courseName: String? = null,
+    val courseCode: String? = null,
+    val score: String? = null,
+)
+
+object GradeScoreCacheStore {
+  private const val KEY_PREFIX = "grade_score_cache"
+  private const val KEY_USER_INDEX = "grade_score_cache_users"
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private var _settings: Settings? = null
+  var settings: Settings
+    get() = _settings ?: Settings().also { _settings = it }
+    set(value) {
+      _settings = value
+    }
+
+  fun save(userKey: String, cache: StoredGradeScoreCache) {
+    addUserKey(userKey)
+    settings.putString(storageKey(userKey), json.encodeToString(cache))
+  }
+
+  fun get(userKey: String): StoredGradeScoreCache? {
+    val raw = settings.getStringOrNull(storageKey(userKey)) ?: return null
+    return runCatching { json.decodeFromString<StoredGradeScoreCache>(raw) }.getOrNull()
+  }
+
+  fun clear(userKey: String) {
+    settings.remove(storageKey(userKey))
+  }
+
+  fun clearAllScopes() {
+    loadUserKeys().forEach { userKey ->
+      ConnectionMode.entries.forEach { mode -> settings.remove(storageKey(userKey, mode)) }
+    }
+    settings.remove(KEY_USER_INDEX)
+  }
+
+  fun clearKnownUserAllModes(userKey: String) {
+    ConnectionMode.entries.forEach { mode -> settings.remove(storageKey(userKey, mode)) }
+  }
+
+  private fun storageKey(
+      userKey: String,
+      mode: ConnectionMode? = ConnectionModeStore.get(),
+  ): String {
+    val effectiveMode = mode ?: ConnectionMode.SERVER_RELAY
+    return "$KEY_PREFIX:${effectiveMode.storageKey}:$userKey"
+  }
+
+  private fun addUserKey(userKey: String) {
+    val keys = loadUserKeys()
+    if (userKey in keys) return
+    settings.putString(KEY_USER_INDEX, json.encodeToString(keys + userKey))
+  }
+
+  private fun loadUserKeys(): List<String> {
+    val raw = settings.getStringOrNull(KEY_USER_INDEX) ?: return emptyList()
+    return runCatching { json.decodeFromString<List<String>>(raw) }.getOrDefault(emptyList())
+  }
+}

--- a/shared/src/commonTest/kotlin/cn/edu/ubaa/api/BykcCourseFilterStoreTest.kt
+++ b/shared/src/commonTest/kotlin/cn/edu/ubaa/api/BykcCourseFilterStoreTest.kt
@@ -20,7 +20,7 @@ class BykcCourseFilterStoreTest {
     BykcCourseFilterStore.settings = MapSettings()
 
     BykcCourseFilterStore.save(
-        "23373270",
+        "test-user",
         StoredBykcCourseFilters(
             statuses = listOf("AVAILABLE", "FULL"),
             categories = listOf("德育"),
@@ -38,7 +38,7 @@ class BykcCourseFilterStoreTest {
             categories = listOf("德育"),
             campuses = listOf("学院路校区"),
         ),
-        BykcCourseFilterStore.get("23373270"),
+        BykcCourseFilterStore.get("test-user"),
     )
     assertEquals(
         StoredBykcCourseFilters(statuses = listOf("ENDED")),
@@ -50,12 +50,12 @@ class BykcCourseFilterStoreTest {
   fun `clear removes only target user filters`() {
     BykcCourseFilterStore.settings = MapSettings()
 
-    BykcCourseFilterStore.save("23373270", StoredBykcCourseFilters(statuses = listOf("AVAILABLE")))
+    BykcCourseFilterStore.save("test-user", StoredBykcCourseFilters(statuses = listOf("AVAILABLE")))
     BykcCourseFilterStore.save("other", StoredBykcCourseFilters(statuses = listOf("ENDED")))
 
-    BykcCourseFilterStore.clear("23373270")
+    BykcCourseFilterStore.clear("test-user")
 
-    assertNull(BykcCourseFilterStore.get("23373270"))
+    assertNull(BykcCourseFilterStore.get("test-user"))
     assertEquals(
         StoredBykcCourseFilters(statuses = listOf("ENDED")),
         BykcCourseFilterStore.get("other"),

--- a/shared/src/commonTest/kotlin/cn/edu/ubaa/api/GradeScoreCacheStoreTest.kt
+++ b/shared/src/commonTest/kotlin/cn/edu/ubaa/api/GradeScoreCacheStoreTest.kt
@@ -1,0 +1,77 @@
+package cn.edu.ubaa.api
+
+import cn.edu.ubaa.api.storage.GradeScoreCacheStore
+import cn.edu.ubaa.api.storage.StoredGradeScoreCache
+import cn.edu.ubaa.api.storage.StoredGradeScoreEntry
+import com.russhwolf.settings.MapSettings
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GradeScoreCacheStoreTest {
+  @AfterTest
+  fun tearDown() {
+    ConnectionModeStore.settings = MapSettings()
+    GradeScoreCacheStore.settings = MapSettings()
+  }
+
+  @Test
+  fun `cache is isolated by user and connection mode`() {
+    ConnectionModeStore.settings = MapSettings()
+    GradeScoreCacheStore.settings = MapSettings()
+
+    ConnectionModeStore.save(ConnectionMode.SERVER_RELAY)
+    GradeScoreCacheStore.save("test-user", sampleCache("2025-2026-1", "95"))
+    GradeScoreCacheStore.save("other", sampleCache("2025-2026-1", "80"))
+
+    assertEquals("95", GradeScoreCacheStore.get("test-user")?.scores?.singleOrNull()?.score)
+    assertEquals("80", GradeScoreCacheStore.get("other")?.scores?.singleOrNull()?.score)
+
+    ConnectionModeStore.save(ConnectionMode.DIRECT)
+
+    assertNull(GradeScoreCacheStore.get("test-user"))
+
+    GradeScoreCacheStore.save("test-user", sampleCache("2025-2026-1", "100"))
+
+    assertEquals("100", GradeScoreCacheStore.get("test-user")?.scores?.singleOrNull()?.score)
+
+    ConnectionModeStore.save(ConnectionMode.SERVER_RELAY)
+
+    assertEquals("95", GradeScoreCacheStore.get("test-user")?.scores?.singleOrNull()?.score)
+  }
+
+  @Test
+  fun `clear all scopes removes indexed cache entries`() {
+    ConnectionModeStore.settings = MapSettings()
+    GradeScoreCacheStore.settings = MapSettings()
+
+    ConnectionModeStore.save(ConnectionMode.SERVER_RELAY)
+    GradeScoreCacheStore.save("test-user", sampleCache("2025-2026-1", "95"))
+    ConnectionModeStore.save(ConnectionMode.DIRECT)
+    GradeScoreCacheStore.save("test-user", sampleCache("2025-2026-1", "100"))
+
+    GradeScoreCacheStore.clearAllScopes()
+
+    assertNull(GradeScoreCacheStore.get("test-user"))
+
+    ConnectionModeStore.save(ConnectionMode.SERVER_RELAY)
+
+    assertNull(GradeScoreCacheStore.get("test-user"))
+  }
+
+  private fun sampleCache(termCode: String, score: String): StoredGradeScoreCache =
+      StoredGradeScoreCache(
+          termCode = termCode,
+          termName = termCode,
+          scores =
+              listOf(
+                  StoredGradeScoreEntry(
+                      key = "course:math",
+                      courseName = "高等数学",
+                      courseCode = "MATH",
+                      score = score,
+                  )
+              ),
+      )
+}

--- a/shared/src/commonTest/kotlin/cn/edu/ubaa/api/YgdkReminderStoreTest.kt
+++ b/shared/src/commonTest/kotlin/cn/edu/ubaa/api/YgdkReminderStoreTest.kt
@@ -18,11 +18,11 @@ class YgdkReminderStoreTest {
   fun `reminder is enabled by default and isolated by user key`() {
     YgdkReminderStore.settings = MapSettings()
 
-    assertTrue(YgdkReminderStore.isEnabled("23373270"))
+    assertTrue(YgdkReminderStore.isEnabled("test-user"))
 
-    YgdkReminderStore.setEnabled("23373270", false)
+    YgdkReminderStore.setEnabled("test-user", false)
 
-    assertFalse(YgdkReminderStore.isEnabled("23373270"))
+    assertFalse(YgdkReminderStore.isEnabled("test-user"))
     assertTrue(YgdkReminderStore.isEnabled("other"))
   }
 
@@ -30,32 +30,32 @@ class YgdkReminderStoreTest {
   fun `week and term done keys are isolated by user and period`() {
     YgdkReminderStore.settings = MapSettings()
 
-    YgdkReminderStore.markWeekDone("23373270", "2025-2026-2:11")
-    YgdkReminderStore.markTermDone("23373270", "2025-2026-2")
+    YgdkReminderStore.markWeekDone("test-user", "2025-2026-2:11")
+    YgdkReminderStore.markTermDone("test-user", "2025-2026-2")
 
-    assertTrue(YgdkReminderStore.isWeekDone("23373270", "2025-2026-2:11"))
-    assertFalse(YgdkReminderStore.isWeekDone("23373270", "2025-2026-2:12"))
+    assertTrue(YgdkReminderStore.isWeekDone("test-user", "2025-2026-2:11"))
+    assertFalse(YgdkReminderStore.isWeekDone("test-user", "2025-2026-2:12"))
     assertFalse(YgdkReminderStore.isWeekDone("other", "2025-2026-2:11"))
-    assertTrue(YgdkReminderStore.isTermDone("23373270", "2025-2026-2"))
-    assertFalse(YgdkReminderStore.isTermDone("23373270", "2026-2027-1"))
+    assertTrue(YgdkReminderStore.isTermDone("test-user", "2025-2026-2"))
+    assertFalse(YgdkReminderStore.isTermDone("test-user", "2026-2027-1"))
     assertFalse(YgdkReminderStore.isTermDone("other", "2025-2026-2"))
   }
 
   @Test
   fun `clear removes only target user reminder state`() {
     YgdkReminderStore.settings = MapSettings()
-    YgdkReminderStore.setEnabled("23373270", false)
-    YgdkReminderStore.markWeekDone("23373270", "2025-2026-2:11")
-    YgdkReminderStore.markTermDone("23373270", "2025-2026-2")
+    YgdkReminderStore.setEnabled("test-user", false)
+    YgdkReminderStore.markWeekDone("test-user", "2025-2026-2:11")
+    YgdkReminderStore.markTermDone("test-user", "2025-2026-2")
     YgdkReminderStore.setEnabled("other", false)
     YgdkReminderStore.markWeekDone("other", "2025-2026-2:11")
     YgdkReminderStore.markTermDone("other", "2025-2026-2")
 
-    YgdkReminderStore.clear("23373270")
+    YgdkReminderStore.clear("test-user")
 
-    assertTrue(YgdkReminderStore.isEnabled("23373270"))
-    assertFalse(YgdkReminderStore.isWeekDone("23373270", "2025-2026-2:11"))
-    assertFalse(YgdkReminderStore.isTermDone("23373270", "2025-2026-2"))
+    assertTrue(YgdkReminderStore.isEnabled("test-user"))
+    assertFalse(YgdkReminderStore.isWeekDone("test-user", "2025-2026-2:11"))
+    assertFalse(YgdkReminderStore.isTermDone("test-user", "2025-2026-2"))
     assertFalse(YgdkReminderStore.isEnabled("other"))
     assertTrue(YgdkReminderStore.isWeekDone("other", "2025-2026-2:11"))
     assertTrue(YgdkReminderStore.isTermDone("other", "2025-2026-2"))


### PR DESCRIPTION
## Summary
- add persistent current-term score cache scoped by user and connection mode
- check current non-empty semester scores from homepage entry/refresh and show score update notice
- add homepage shortcut to scores page and watcher/cache tests

Closes #81

## Tests
- ./gradlew :shared:jvmTest :composeApp:jvmTest